### PR TITLE
Handle missing file in Excel import

### DIFF
--- a/produkty/views.py
+++ b/produkty/views.py
@@ -63,7 +63,7 @@ logger = logging.getLogger(__name__)
 
 @login_required
 def import_excel(request):
-    if request.method == 'POST' and request.FILES['file']:
+    if request.method == 'POST' and 'file' in request.FILES:
         excel_file = request.FILES['file']
         wb = openpyxl.load_workbook(excel_file)
         sheet = wb.active
@@ -103,8 +103,11 @@ def import_excel(request):
                 )
             except Exception as e:
                 logger.error(f"Błąd podczas tworzenia produktu w wierszu {idx}: {e}")
-        
+
         return render(request, 'produkty/import_success.html')
+    elif request.method == 'POST':
+        # Brak pliku w żądaniu POST
+        return render(request, 'produkty/import_form.html', {'error': 'Nie wybrano pliku do importu.'})
 
     return render(request, 'produkty/import_form.html')
 


### PR DESCRIPTION
## Summary
- prevent KeyError in `import_excel` by checking `request.FILES` for `'file'`
- inform user when an import is attempted without providing a file

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688fb30b47b8832b8556a2527261f779