### PR TITLE
Persist sale data from suggestion form

### DIFF
--- a/beko_project/settings_test.py
+++ b/beko_project/settings_test.py
@@ -1,0 +1,9 @@
+from .settings import *
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+}
+

--- a/produkty/templates/produkty/sprzedaz_sugestie.html
+++ b/produkty/templates/produkty/sprzedaz_sugestie.html
@@ -6,6 +6,11 @@
     <h1>Sugestie dla nieznanych modeli</h1>
     <form method="post">
         {% csrf_token %}
+        <input type="hidden" name="sugestie_zatwierdzone" value="1">
+        <input type="hidden" name="data_sprzedazy" value="{{ data_sprzedazy }}">
+        {% for model in zatwierdzone_modele %}
+            <input type="hidden" name="model_{{ forloop.counter }}" value="{{ model }}">
+        {% endfor %}
         <p>Data sprzedaży: {{ data_sprzedazy }}</p>
         <ul>
             {% for wpis, sugestia in sugestie %}

--- a/produkty/tests.py
+++ b/produkty/tests.py
@@ -1,3 +1,49 @@
-from django.test import TestCase
+from django.contrib.auth.models import User
+from django.test import Client, TestCase, override_settings
+from django.urls import reverse
 
-# Create your tests here.
+from .models import Produkt, Sprzedaz
+
+
+@override_settings(
+    DATABASES={"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}
+)
+class SprzedazSugestieTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="tester", password="pass")
+        self.client = Client()
+        self.client.login(username="tester", password="pass")
+
+    def test_suggestion_flow_creates_sale(self):
+        Produkt.objects.create(model="ABC123", stawka=10, grupa_towarowa="AGD")
+        data_sprzedazy = "2024-01-01"
+
+        response = self.client.post(
+            reverse("produkty:sprzedaz"),
+            {
+                "data_sprzedazy": data_sprzedazy,
+                "modele_sprzedazy": "ABC124",
+            },
+        )
+
+        self.assertTemplateUsed(response, "produkty/sprzedaz_sugestie.html")
+
+        response = self.client.post(
+            reverse("produkty:sprzedaz"),
+            {
+                "sugestie_zatwierdzone": "1",
+                "data_sprzedazy": data_sprzedazy,
+                "model_1": "ABC123",
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            Sprzedaz.objects.filter(produkt__model="ABC123").count(),
+            1,
+        )
+
+        summary = self.client.get(reverse("produkty:podsumowanie_sprzedazy"))
+        models_in_summary = [d["model"] for d in summary.context["sprzedaz"].values()]
+        self.assertIn("ABC123", models_in_summary)
+


### PR DESCRIPTION
## Summary
- preserve sale date and approval state with hidden fields on suggestion form
- cover full suggestion approval flow with tests
- add test settings module for SQLite-backed tests

## Testing
- `python manage.py test --settings=beko_project.settings_test`


------
https://chatgpt.com/codex/tasks/task_e_6891fb909a20832bbf1406faa1bdb260