### PR TITLE
Add template loader imports for test view

### DIFF
--- a/produkty/views.py
+++ b/produkty/views.py
@@ -17,6 +17,8 @@ from django.contrib.auth.decorators import login_required
 from openpyxl.styles import PatternFill, Font, Alignment, Border, Side
 from openpyxl.utils import get_column_letter
 from io import BytesIO
+from django.template.loader import get_template
+from django.template import TemplateDoesNotExist
 
 @login_required
 def test_template(request):


### PR DESCRIPTION
## Summary
- import `get_template` and `TemplateDoesNotExist` so `test_template` view can load templates safely

## Testing
- `python manage.py test --settings=beko_project.settings_test`


------
https://chatgpt.com/codex/tasks/task_e_68943bc272d8832b81b67186dda99a55