### PR TITLE
Toggle zadaniowka fields by type

### DIFF
--- a/produkty/static/produkty/js/zadaniowka_form.js
+++ b/produkty/static/produkty/js/zadaniowka_form.js
@@ -1,0 +1,32 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const typSelect = document.getElementById('typ');
+    if (!typSelect) {
+        return;
+    }
+
+    function updateVisibility() {
+        const typ = typSelect.value;
+        const groups = document.querySelectorAll('.mix-prowizja-only, .mix-mnoznik-only, .konkretne-modele-only');
+        groups.forEach(el => {
+            el.style.display = 'none';
+        });
+
+        if (typ === 'MIX_PROWIZJA') {
+            document.querySelectorAll('.mix-prowizja-only').forEach(el => {
+                el.style.display = '';
+            });
+        } else if (typ === 'MIX_MNOZNIK') {
+            document.querySelectorAll('.mix-mnoznik-only').forEach(el => {
+                el.style.display = '';
+            });
+        } else if (typ === 'KONKRETNE_MODELE') {
+            document.querySelectorAll('.konkretne-modele-only').forEach(el => {
+                el.style.display = '';
+            });
+        }
+    }
+
+    typSelect.addEventListener('change', updateVisibility);
+    updateVisibility();
+});
+

--- a/produkty/templates/produkty/base.html
+++ b/produkty/templates/produkty/base.html
@@ -174,6 +174,7 @@
     </div>
 
     <script src="{% static 'produkty/js/zadaniowka_filter.js' %}"></script>
+    <script src="{% static 'produkty/js/zadaniowka_form.js' %}"></script>
     <script>
     document.addEventListener('DOMContentLoaded', () => {
         const sidebar = document.getElementById('sidebar');

--- a/produkty/templates/produkty/zadaniowka_form.html
+++ b/produkty/templates/produkty/zadaniowka_form.html
@@ -28,12 +28,12 @@
         </div>
 
         <div class="row">
-            <div class="col-md-6 mb-3">
+            <div class="col-md-6 mb-3 konkretne-modele-only">
                 <label for="minimalna_liczba_sztuk" class="form-label">Minimalna liczba sztuk</label>
                 <input type="number" class="form-control" id="minimalna_liczba_sztuk" name="minimalna_liczba_sztuk" value="{{ zadaniowka.minimalna_liczba_sztuk|default:'0' }}" min="0">
             </div>
 
-            <div class="col-md-6 mb-3">
+            <div class="col-md-6 mb-3 mix-prowizja-only mix-mnoznik-only">
                 <label for="prog_mix" class="form-label">Próg mixu</label>
                 <input type="number" class="form-control" id="prog_mix" name="prog_mix" value="{{ zadaniowka.prog_mix|default:'0' }}" min="0">
             </div>
@@ -57,17 +57,17 @@
                 <input type="number" class="form-control" id="mnoznik_stawki" name="mnoznik_stawki" value="{{ zadaniowka.mnoznik_stawki|default:'1.0' }}" step="0.01" min="0">
             </div>
 
-            <div class="col-md-3 mb-3">
+            <div class="col-md-3 mb-3 mix-mnoznik-only">
                 <label for="mnoznik_mix" class="form-label">Mnożnik mixu</label>
                 <input type="number" class="form-control" id="mnoznik_mix" name="mnoznik_mix" value="{{ zadaniowka.mnoznik_mix|default:'' }}" step="0.01" min="0">
             </div>
 
-            <div class="col-md-3 mb-3">
+            <div class="col-md-3 mb-3 mix-prowizja-only konkretne-modele-only">
                 <label for="premia_za_minimalna_liczbe" class="form-label">Premia za min. liczbę</label>
                 <input type="number" class="form-control" id="premia_za_minimalna_liczbe" name="premia_za_minimalna_liczbe" value="{{ zadaniowka.premia_za_minimalna_liczbe|default:'0' }}" step="0.01" min="0">
             </div>
 
-            <div class="col-md-3 mb-3">
+            <div class="col-md-3 mb-3 konkretne-modele-only">
                 <label for="premia_za_dodatkowa_liczbe" class="form-label">Premia za dodatkową</label>
                 <input type="number" class="form-control" id="premia_za_dodatkowa_liczbe" name="premia_za_dodatkowa_liczbe" value="{{ zadaniowka.premia_za_dodatkowa_liczbe|default:'0' }}" step="0.01" min="0">
             </div>


### PR DESCRIPTION
## Summary
- wrap task form fields in type-specific containers
- add JS to toggle form fields based on selected task type
- load new script in base template

## Testing
- `python manage.py test --settings=beko_project.settings_test`

------
https://chatgpt.com/codex/tasks/task_e_6895a64bf254832b989e009765764ebd