### PR TITLE
feat: usprawnienia listy produktow, zadan, kalendarza i przeglad grup/marek

### DIFF
--- a/produkty/static/produkty/js/lista_produktow.js
+++ b/produkty/static/produkty/js/lista_produktow.js
@@ -1,4 +1,57 @@
-// This file can be used for future enhancements to the product list page.
-document.addEventListener('DOMContentLoaded', function() {
-    // Tutaj można dodać kod, który ma być wykonany po załadowaniu strony
+// Dynamiczne filtrowanie listy produktow po modelu (bez przeladowania strony).
+document.addEventListener('DOMContentLoaded', function () {
+    const input = document.getElementById('modelLiveFilter');
+    if (!input) return;
+
+    const emptyMsg = document.getElementById('liveFilterEmpty');
+    // Wszystkie wiersze produktow (dzialaja zarowno w widoku tabeli, jak i w grupowaniu).
+    const rows = Array.from(document.querySelectorAll('tr[data-model]'));
+    const groupItems = Array.from(document.querySelectorAll('[data-group-item]'));
+
+    function applyFilter() {
+        const q = input.value.trim().toLowerCase();
+        let visibleCount = 0;
+
+        rows.forEach(function (row) {
+            const model = row.getAttribute('data-model') || '';
+            const match = q === '' || model.indexOf(q) !== -1;
+            row.style.display = match ? '' : 'none';
+            if (match) visibleCount++;
+        });
+
+        // Widok grupowany: pokazuj tylko grupy, ktore maja pasujace wiersze,
+        // i automatycznie rozwijaj je podczas wyszukiwania.
+        groupItems.forEach(function (item) {
+            const itemRows = item.querySelectorAll('tr[data-model]');
+            let anyVisible = false;
+            itemRows.forEach(function (r) {
+                if (r.style.display !== 'none') anyVisible = true;
+            });
+            item.style.display = anyVisible ? '' : 'none';
+
+            const collapse = item.querySelector('.accordion-collapse');
+            const button = item.querySelector('.accordion-button');
+            if (collapse && button) {
+                if (q !== '' && anyVisible) {
+                    collapse.classList.add('show');
+                    button.classList.remove('collapsed');
+                    button.setAttribute('aria-expanded', 'true');
+                } else if (q === '') {
+                    // Po wyczyszczeniu pola przywracamy zwiniete grupy.
+                    collapse.classList.remove('show');
+                    button.classList.add('collapsed');
+                    button.setAttribute('aria-expanded', 'false');
+                }
+            }
+        });
+
+        if (emptyMsg) {
+            emptyMsg.classList.toggle('d-none', visibleCount !== 0);
+        }
+    }
+
+    input.addEventListener('input', applyFilter);
+
+    // Jesli pole ma juz wartosc (np. po przeslaniu formularza), zastosuj od razu.
+    if (input.value.trim() !== '') applyFilter();
 });

--- a/produkty/templates/produkty/base.html
+++ b/produkty/templates/produkty/base.html
@@ -94,6 +94,7 @@
                     <a href="#" class="submenu-toggle"><i class="fas fa-user-shield"></i> Admin <i class="fas fa-chevron-down float-end"></i></a>
                     <ul class="submenu">
                         <li><a href="{% url 'produkty:import_excel' %}">Import produktów</a></li>
+                        <li><a href="{% url 'produkty:grupy_marki' %}">Grupy i marki (przegląd)</a></li>
                         <li><a href="{% url 'produkty:konta_lista' %}">Zarządzanie kontami</a></li>
                         <li><a href="{% url 'produkty:wyciagnij_liste_modeli' %}">Wyciągnij listę modeli</a></li>
                         <li><a href="{% url 'produkty:delete_sales_for_day' %}">Usuń sprzedaż z dnia</a></li>

--- a/produkty/templates/produkty/calendar.html
+++ b/produkty/templates/produkty/calendar.html
@@ -15,6 +15,11 @@
         </div>
     </div>
 
+    <div class="d-flex flex-wrap gap-3 mb-2 small">
+        <span><span class="badge bg-success">Otwarty</span> dzień pracy otwarty</span>
+        <span><span class="badge bg-secondary">Zamknięty</span> dzień pracy zamknięty</span>
+    </div>
+
     <table class="calendar">
         <thead>
             <tr>
@@ -33,9 +38,18 @@
                 {% for day in week %}
                 <td class="{% if day == 0 %}empty-day{% elif year == today.year and month == today.month and day == today.day %}today{% endif %}">
                     {% if day != 0 %}
-                        {% with sales_data=sales_by_day|get_item:day %}
+                        {% with sales_data=sales_by_day|get_item:day work_data=work_days|get_item:day %}
                             <a href="{% url 'produkty:daily_sales' year month day %}" class="day-link">
                                 <div class="day-number">{{ day }}</div>
+                                {% if work_data %}
+                                <div class="day-status">
+                                    {% if work_data.zamkniety %}
+                                    <span class="badge bg-secondary">Zamknięty</span>
+                                    {% else %}
+                                    <span class="badge bg-success">Otwarty</span>
+                                    {% endif %}
+                                </div>
+                                {% endif %}
                                 {% if sales_data %}
                                 <div class="sales-count">
                                     <strong>Sztuk: {{ sales_data.total_items }}</strong><br>

--- a/produkty/templates/produkty/grupy_marki.html
+++ b/produkty/templates/produkty/grupy_marki.html
@@ -1,0 +1,87 @@
+{% extends "produkty/base.html" %}
+{% load produkty_tags %}
+
+{% block title %}Grupy i marki — przegląd{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Grupy towarowe i marki — przegląd</h2>
+    <p class="text-muted">
+        Lista wszystkich wartości zapisanych w bazie wraz z liczbą produktów.
+        Służy do wychwycenia błędnie zapisanych wartości (literówki, puste, „NIEZNANA").
+        Kliknij wartość, aby zobaczyć produkty i je poprawić.
+    </p>
+
+    <div class="row">
+        <div class="col-md-6 mb-4">
+            <div class="card">
+                <div class="card-header bg-primary text-white">
+                    <i class="fas fa-layer-group me-1"></i> Grupy towarowe ({{ liczba_grup }})
+                </div>
+                <div class="card-body p-0">
+                    <table class="table table-striped table-hover mb-0">
+                        <thead>
+                            <tr>
+                                <th>Grupa towarowa</th>
+                                <th class="text-center">Produktów</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for g in grupy %}
+                            <tr>
+                                <td>
+                                    {% if g.grupa_towarowa %}
+                                    <a href="{% url 'produkty:lista_produktow' %}?grupa_towarowa={{ g.grupa_towarowa|urlencode }}">{{ g.grupa_towarowa }}</a>
+                                    {% else %}
+                                    <span class="text-danger fst-italic">(puste / brak)</span>
+                                    {% endif %}
+                                </td>
+                                <td class="text-center">{{ g.liczba }}</td>
+                            </tr>
+                            {% empty %}
+                            <tr><td colspan="2" class="text-center">Brak danych.</td></tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-md-6 mb-4">
+            <div class="card">
+                <div class="card-header bg-dark text-white">
+                    <i class="fas fa-tags me-1"></i> Marki ({{ liczba_marek }})
+                </div>
+                <div class="card-body p-0">
+                    <table class="table table-striped table-hover mb-0">
+                        <thead>
+                            <tr>
+                                <th>Marka</th>
+                                <th class="text-center">Produktów</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for m in marki %}
+                            <tr>
+                                <td>
+                                    {% if m.marka %}
+                                    <a href="{% url 'produkty:lista_produktow' %}?marka={{ m.marka|urlencode }}">{{ m.marka }}</a>
+                                    {% else %}
+                                    <span class="text-danger fst-italic">(puste / brak)</span>
+                                    {% endif %}
+                                </td>
+                                <td class="text-center">{{ m.liczba }}</td>
+                            </tr>
+                            {% empty %}
+                            <tr><td colspan="2" class="text-center">Brak danych.</td></tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <a href="{% url 'produkty:lista_produktow' %}" class="btn btn-secondary">← Powrót do listy produktów</a>
+</div>
+{% endblock %}

--- a/produkty/templates/produkty/lista_produktow.html
+++ b/produkty/templates/produkty/lista_produktow.html
@@ -8,47 +8,67 @@
 <div class="container mt-4">
     <h2>Lista Produktów</h2>
 
-    <form method="get" class="mb-4">
-        <div class="row">
+    <form method="get" class="mb-3">
+        <div class="row g-2 align-items-end">
             <div class="col-md-3">
-                <input type="text" name="model" class="form-control" placeholder="Filtruj po modelu" value="{{ model_filter }}">
+                <label class="form-label small mb-1">Model (filtruje w locie)</label>
+                <input type="text" name="model" id="modelLiveFilter" class="form-control"
+                       placeholder="Zacznij wpisywać model..." value="{{ model_filter }}" autocomplete="off">
             </div>
             <div class="col-md-3">
-                <input type="text" name="marka" class="form-control" placeholder="Filtruj po marce" value="{{ marka_filter }}">
+                <label class="form-label small mb-1">Marka</label>
+                <select name="marka" class="form-select">
+                    <option value="">— wszystkie marki —</option>
+                    {% for m in dostepne_marki %}
+                    <option value="{{ m }}" {% if m == marka_filter %}selected{% endif %}>{{ m }}</option>
+                    {% endfor %}
+                </select>
             </div>
             <div class="col-md-2">
-                <input type="text" name="grupa_towarowa" class="form-control" placeholder="Filtruj po grupie" value="{{ grupa_towarowa_filter }}">
+                <label class="form-label small mb-1">Grupa towarowa</label>
+                <select name="grupa_towarowa" class="form-select">
+                    <option value="">— wszystkie grupy —</option>
+                    {% for g in dostepne_grupy %}
+                    <option value="{{ g }}" {% if g == grupa_towarowa_filter %}selected{% endif %}>{{ g }}</option>
+                    {% endfor %}
+                </select>
             </div>
             <div class="col-md-1">
+                <label class="form-label small mb-1">Stawka od</label>
                 <input type="number" step="0.01" name="prowizja_od" class="form-control" placeholder="Od" value="{{ prowizja_od }}">
             </div>
             <div class="col-md-1">
+                <label class="form-label small mb-1">Stawka do</label>
                 <input type="number" step="0.01" name="prowizja_do" class="form-control" placeholder="Do" value="{{ prowizja_do }}">
             </div>
-            <div class="col-md-2">
+            <div class="col-md-2 d-grid">
                 <button type="submit" class="btn btn-primary">Filtruj</button>
             </div>
         </div>
+        <div class="form-text mt-1">
+            Pole „Model" ukrywa niepasujące wiersze od razu podczas pisania. Marka i grupa działają po kliknięciu „Filtruj".
+        </div>
     </form>
 
-    <div class="mb-4">
-        <a href="?{% query_transform group='marka' %}" class="btn btn-secondary">Grupuj po marce</a>
-        <a href="?{% query_transform group='grupa_towarowa' %}" class="btn btn-secondary">Grupuj po grupie produktowej</a>
-        <a href="?{% query_transform group='' %}" class="btn btn-info">Pokaż wszystko</a>
+    <div class="mb-3 d-flex flex-wrap gap-2">
+        <a href="?{% query_transform group='marka' %}" class="btn btn-outline-secondary btn-sm">Grupuj po marce</a>
+        <a href="?{% query_transform group='grupa_towarowa' %}" class="btn btn-outline-secondary btn-sm">Grupuj po grupie towarowej</a>
+        <a href="?{% query_transform group='' %}" class="btn btn-outline-info btn-sm">Pokaż wszystko (bez grupowania)</a>
     </div>
 
     {% if grouped_produkty %}
+        <p class="text-muted small">Kliknij nazwę grupy, aby ją rozwinąć.</p>
         <div class="accordion" id="groupedProduktyAccordion">
             {% for group_name, product_list in grouped_produkty.items %}
-                <div class="accordion-item">
+                <div class="accordion-item" data-group-item>
                     <h2 class="accordion-header" id="heading-{{ forloop.counter }}">
-                        <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-{{ forloop.counter }}" aria-expanded="true" aria-controls="collapse-{{ forloop.counter }}">
-                            {{ group_name }} ({{ product_list|length }})
+                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-{{ forloop.counter }}" aria-expanded="false" aria-controls="collapse-{{ forloop.counter }}">
+                            {{ group_name|default:"(brak / puste)" }} <span class="badge bg-secondary ms-2">{{ product_list|length }}</span>
                         </button>
                     </h2>
-                    <div id="collapse-{{ forloop.counter }}" class="accordion-collapse collapse show" aria-labelledby="heading-{{ forloop.counter }}" data-bs-parent="#groupedProduktyAccordion">
+                    <div id="collapse-{{ forloop.counter }}" class="accordion-collapse collapse" aria-labelledby="heading-{{ forloop.counter }}" data-bs-parent="#groupedProduktyAccordion">
                         <div class="accordion-body">
-                            <table class="table table-striped table-bordered">
+                            <table class="table table-striped table-bordered mb-0">
                                 <thead class="table-dark">
                                     <tr>
                                         <th>Model</th>
@@ -60,7 +80,7 @@
                                 </thead>
                                 <tbody>
                                     {% for produkt in product_list %}
-                                    <tr>
+                                    <tr data-model="{{ produkt.model|lower }}">
                                         <td>{{ produkt.model }}</td>
                                         <td>{{ produkt.marka }}</td>
                                         <td>{{ produkt.grupa_towarowa }}</td>
@@ -79,7 +99,7 @@
             {% endfor %}
         </div>
     {% else %}
-        <table class="table table-striped table-bordered">
+        <table class="table table-striped table-bordered" id="produktyTable">
             <thead class="table-dark">
                 <tr>
                     <th><a href="?sort=model&dir={% if sort == 'model' and dir == 'asc' %}desc{% else %}asc{% endif %}&model={{ model_filter }}&marka={{ marka_filter }}&grupa_towarowa={{ grupa_towarowa_filter }}&prowizja_od={{ prowizja_od }}&prowizja_do={{ prowizja_do }}">Model</a></th>
@@ -91,7 +111,7 @@
             </thead>
             <tbody>
                 {% for produkt in produkty %}
-                <tr>
+                <tr data-model="{{ produkt.model|lower }}">
                     <td>{{ produkt.model }}</td>
                     <td>{{ produkt.marka }}</td>
                     <td>{{ produkt.grupa_towarowa }}</td>
@@ -102,12 +122,13 @@
                     </td>
                 </tr>
                 {% empty %}
-                <tr>
+                <tr class="no-live-hide">
                     <td colspan="5" class="text-center">Brak produktów spełniających kryteria.</td>
                 </tr>
                 {% endfor %}
             </tbody>
         </table>
+        <p id="liveFilterEmpty" class="text-center text-muted d-none">Brak produktów pasujących do wpisanego modelu.</p>
     {% endif %}
 </div>
 
@@ -115,5 +136,5 @@
 {% endblock %}
 
 {% block extra_js %}
-<script src="{% static 'produkty/js/lista_produktow.js' %}"></script>
+<script src="{% static 'produkty/js/lista_produktow.js' %}?v=2"></script>
 {% endblock %}

--- a/produkty/templates/produkty/szczegoly_zadania.html
+++ b/produkty/templates/produkty/szczegoly_zadania.html
@@ -31,6 +31,17 @@
                 {% endif %}
             </div>
 
+            <div class="alert alert-info mt-3 mb-0 small" role="alert">
+                <i class="fas fa-info-circle me-1"></i>
+                Do postępu liczy się sprzedaż <strong>dokładnie tych modeli</strong>, które są przypisane do zadania,
+                i tylko z datą <strong>w okresie {{ zadanie.data_start }} – {{ zadanie.data_koniec }}</strong>.
+                Podobny, ale inny numer modelu (albo sprzedaż z innego dnia) nie zostanie policzona.
+                {% if postep == 0 and ma_sprzedaz_historyczna %}
+                <br><strong>Uwaga:</strong> te modele mają sprzedaż w ostatnim czasie, ale poza okresem zadania —
+                sprawdź daty sprzedaży (kolumna „W okresie zadania" poniżej pokazuje, co wpada w okres).
+                {% endif %}
+            </div>
+
             <hr>
 
             <div class="row">
@@ -78,7 +89,8 @@
                         <thead class="table-light">
                             <tr>
                                 <th>Model z zadania</th>
-                                <th>Sprzedaż (ost. {{ selected_days }} dni)</th>
+                                <th class="text-center">Sprzedaż (ost. {{ selected_days }} dni)</th>
+                                <th class="text-center">W okresie zadania</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -86,6 +98,13 @@
                             <tr class="{% if forloop.counter <= 3 %}table-success{% endif %}">
                                 <td><strong>{{ item.produkt.model }}</strong> ({{ item.produkt.marka }})</td>
                                 <td class="text-center"><strong>{{ item.sztuk }}</strong> szt.</td>
+                                <td class="text-center">
+                                    {% if item.w_okresie %}
+                                    <strong class="text-success">{{ item.w_okresie }}</strong> szt.
+                                    {% else %}
+                                    <span class="text-muted">0</span>
+                                    {% endif %}
+                                </td>
                             </tr>
                             {% endfor %}
                         </tbody>

--- a/produkty/tests_smoke.py
+++ b/produkty/tests_smoke.py
@@ -1,0 +1,57 @@
+from datetime import date, timedelta
+from decimal import Decimal
+
+from django.contrib.auth.models import User
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from .models import Produkt, Sprzedaz, Zadanie, DzienPracy
+
+
+class SmokeRenderTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="smoke", password="pass", is_staff=True)
+        self.client = Client()
+        self.client.login(username="smoke", password="pass")
+        self.today = date.today()
+
+        self.p1 = Produkt.objects.create(model="B3RCNA404HXBR", stawka=Decimal("15"), grupa_towarowa="CHLODNICTWO", marka="BEKO")
+        self.p2 = Produkt.objects.create(model="B3RCNA364HXBR", stawka=Decimal("10"), grupa_towarowa="", marka="")
+        # sprzedaz p1 w tym miesiacu (do postepu i kalendarza)
+        Sprzedaz.objects.create(produkt=self.p1, liczba_sztuk=2, data_sprzedazy=self.today)
+        # sprzedaz p1 spoza okresu zadania (200 dni temu) - do wskazowki diagnostycznej
+        Sprzedaz.objects.create(produkt=self.p1, liczba_sztuk=1, data_sprzedazy=self.today - timedelta(days=200))
+
+        DzienPracy.objects.create(user=self.user, data=self.today)
+
+        self.zad = Zadanie.objects.create(
+            nazwa="Chlodnictwo", data_start=self.today, data_koniec=self.today, prog_1=8, prog_2=12,
+        )
+        self.zad.produkty.set([self.p1, self.p2])
+
+    def test_lista_produktow(self):
+        r = self.client.get(reverse("produkty:lista_produktow"))
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("dostepne_grupy", r.context)
+        self.assertIn("dostepne_marki", r.context)
+
+    def test_lista_produktow_grouped(self):
+        r = self.client.get(reverse("produkty:lista_produktow") + "?group=grupa_towarowa")
+        self.assertEqual(r.status_code, 200)
+
+    def test_grupy_marki(self):
+        r = self.client.get(reverse("produkty:grupy_marki"))
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, "CHLODNICTWO")
+
+    def test_calendar(self):
+        r = self.client.get(reverse("produkty:calendar", args=[self.today.year, self.today.month]))
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("work_days", r.context)
+        self.assertIn(self.today.day, r.context["work_days"])
+
+    def test_szczegoly_zadania(self):
+        r = self.client.get(reverse("produkty:szczegoly_zadania", args=[self.zad.id]))
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.context["postep"], 2)
+        self.assertTrue(r.context["ma_sprzedaz_historyczna"])

--- a/produkty/urls.py
+++ b/produkty/urls.py
@@ -5,6 +5,7 @@ app_name = 'produkty'  # Dodaj to, aby ustawić namespace dla aplikacji
 
 urlpatterns = [
     path('produkty/', views.lista_produktow, name='lista_produktow'),
+    path('produkty/grupy-marki/', views.grupy_marki_przeglad, name='grupy_marki'),
     path('produkty/edit/<int:product_id>/', views.product_edit, name='product_edit'),
     path('', views.home, name='home'),
     path('import/', views.import_excel, name='import_excel'),

--- a/produkty/views.py
+++ b/produkty/views.py
@@ -898,15 +898,24 @@ def szczegoly_zadania(request, zadanie_id):
     ).values('produkt').annotate(ilosc=Sum('liczba_sztuk'))
     
     historia_dict = {item['produkt']: item['ilosc'] for item in historyczne_sprzedaze}
-    
+
+    # Sprzedaz DOKLADNIE w okresie zadania, per produkt - to wlasnie liczy sie do postepu.
+    w_okresie_qs = sprzedaz_w_okresie.values('produkt').annotate(ilosc=Sum('liczba_sztuk'))
+    w_okresie_dict = {item['produkt']: item['ilosc'] for item in w_okresie_qs}
+
     analiza_dane = []
     for prod in modele_w_zadaniu:
         sztuk = historia_dict.get(prod.id, 0)
         analiza_dane.append({
             'produkt': prod,
-            'sztuk': sztuk
+            'sztuk': sztuk,
+            'w_okresie': w_okresie_dict.get(prod.id, 0),
         })
     analiza_dane.sort(key=lambda x: x['sztuk'], reverse=True)
+
+    # Wskazowka diagnostyczna: sa sprzedaze modeli zadania w ostatnim okresie,
+    # ale postep = 0 -> najpewniej sprzedaz ma date spoza okresu zadania.
+    ma_sprzedaz_historyczna = any(item['sztuk'] > 0 for item in analiza_dane)
 
     context = {
         'zadanie': zadanie,
@@ -917,6 +926,7 @@ def szczegoly_zadania(request, zadanie_id):
         'prog_2_status': prog_2_status,
         'analiza_dane': analiza_dane,
         'selected_days': days_int,
+        'ma_sprzedaz_historyczna': ma_sprzedaz_historyczna,
     }
 
     return render(request, 'produkty/szczegoly_zadania.html', context)
@@ -1206,6 +1216,16 @@ def calendar_view(request, year=None, month=None):
         } for sale in sales_in_month
     }
 
+    # Status dni pracy (otwarty/zamkniety) dla zalogowanego uzytkownika
+    dni_pracy = DzienPracy.objects.filter(
+        user=request.user, data__year=year, data__month=month
+    )
+    work_days = {
+        dp.data.day: {
+            'zamkniety': dp.czas_zamkniecia is not None,
+        } for dp in dni_pracy
+    }
+
     # Ustawienia kalendarza
     cal = calendar.Calendar()
     month_days = cal.monthdayscalendar(year, month)
@@ -1221,6 +1241,7 @@ def calendar_view(request, year=None, month=None):
         'month_name': calendar.month_name[month],
         'month_days': month_days,
         'sales_by_day': sales_by_day,
+        'work_days': work_days,
         'today': today,
         'prev_year': prev_month_date.year,
         'prev_month': prev_month_date.month,
@@ -1341,6 +1362,17 @@ def lista_produktow(request):
     if not grouped_produkty:
         produkty = produkty.order_by(sort_by)
 
+    # Listy do filtrow rozwijanych (grupy towarowe i marki) - liczone z calej bazy,
+    # nie z przefiltrowanego zbioru, zeby zawsze mozna bylo wybrac dowolna wartosc.
+    dostepne_grupy = (
+        Produkt.objects.exclude(grupa_towarowa__isnull=True).exclude(grupa_towarowa='')
+        .values_list('grupa_towarowa', flat=True).distinct().order_by('grupa_towarowa')
+    )
+    dostepne_marki = (
+        Produkt.objects.exclude(marka__isnull=True).exclude(marka='')
+        .values_list('marka', flat=True).distinct().order_by('marka')
+    )
+
     context = {
         'produkty': produkty,
         'grouped_produkty': grouped_produkty,
@@ -1352,8 +1384,33 @@ def lista_produktow(request):
         'prowizja_do': prowizja_do,
         'sort': request.GET.get('sort', 'model'),
         'dir': request.GET.get('dir', 'asc'),
+        'dostepne_grupy': dostepne_grupy,
+        'dostepne_marki': dostepne_marki,
     }
     return render(request, 'produkty/lista_produktow.html', context)
+
+@staff_member_required
+def grupy_marki_przeglad(request):
+    """Przeglad samych grup towarowych i marek (z licznikami) - do wychwycenia
+    i poprawy blednie zapisanych wartosci. Kazda pozycja linkuje do listy
+    produktow przefiltrowanej po tej wartosci."""
+    grupy = (
+        Produkt.objects.values('grupa_towarowa')
+        .annotate(liczba=Count('id'))
+        .order_by('grupa_towarowa')
+    )
+    marki = (
+        Produkt.objects.values('marka')
+        .annotate(liczba=Count('id'))
+        .order_by('marka')
+    )
+    context = {
+        'grupy': grupy,
+        'marki': marki,
+        'liczba_grup': grupy.count(),
+        'liczba_marek': marki.count(),
+    }
+    return render(request, 'produkty/grupy_marki.html', context)
 
 @login_required
 def product_edit(request, product_id):


### PR DESCRIPTION
## Cel

Sześć usprawnień zgłoszonych przez użytkownika: lista produktów (grupowanie, dynamiczny filtr, listy rozwijane), czytelniejsze zadania, statusy dni na kalendarzu, przegląd grup i marek dla admina.

> Uwaga: ta gałąź bazuje na commicie porządkowym (`refactor: porzadki...`, PR #16), bo funkcje zależą od poprawki `settings.py`. Jeśli PR #16 zostanie scalony pierwszy, tutaj zostanie tylko commit z funkcjami.

## Co się zmieniło

### Lista produktów
- **Filtry marki i grupy towarowej jako listy rozwijane** — wartości pobierane z bazy, koniec z ręcznym wpisywaniem.
- **Dynamiczne filtrowanie po modelu w locie** — pole „Model" ukrywa niepasujące wiersze podczas pisania, bez przeładowania. W widoku grupowym automatycznie rozwija grupy z trafieniami.
- **Grupowanie domyślnie zwinięte** + licznik produktów przy nazwie grupy (wcześniej wszystko rozwinięte = rozjechana strona).

### Zadania (bez zmiany logiki liczenia — dokładne modele + okres)
- Czytelne wyjaśnienie na stronie zadania: postęp liczy **dokładnie przypisane modele** i tylko sprzedaż **z datą w okresie zadania**.
- Ostrzeżenie, gdy postęp = 0, a modele mają sprzedaż w ostatnim czasie (sygnał, że sprzedaż jest spoza okresu — problem z datą).
- Nowa kolumna **„W okresie zadania"** obok analizy z ostatnich N dni.

### Kalendarz
- Znacznik statusu dnia pracy: **Otwarty** (zielony) / **Zamknięty** (szary) + legenda.

### Panel admina
- Nowy widok **„Grupy i marki"** (staff-only) z licznikami produktów, oznaczeniem pustych/błędnych wartości i linkami do przefiltrowanej listy produktów — do czyszczenia błędnie zapisanych grup/marek.

## Testy
`python manage.py test` — **20/20 przechodzi** (dodany `tests_smoke.py` renderujący zmienione/nowe widoki, bez zmiennych środowiskowych).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
