### PR TITLE
feat: narzedzie admina - masowa zamiana marka <-> grupa towarowa

### DIFF
--- a/produkty/templates/produkty/base.html
+++ b/produkty/templates/produkty/base.html
@@ -95,6 +95,7 @@
                     <ul class="submenu">
                         <li><a href="{% url 'produkty:import_excel' %}">Import produktów</a></li>
                         <li><a href="{% url 'produkty:grupy_marki' %}">Grupy i marki (przegląd)</a></li>
+                        <li><a href="{% url 'produkty:zamiana_marka_grupa' %}">Zamiana marka ↔ grupa</a></li>
                         <li><a href="{% url 'produkty:konta_lista' %}">Zarządzanie kontami</a></li>
                         <li><a href="{% url 'produkty:wyciagnij_liste_modeli' %}">Wyciągnij listę modeli</a></li>
                         <li><a href="{% url 'produkty:delete_sales_for_day' %}">Usuń sprzedaż z dnia</a></li>

--- a/produkty/templates/produkty/zamiana_marka_grupa.html
+++ b/produkty/templates/produkty/zamiana_marka_grupa.html
@@ -1,0 +1,99 @@
+{% extends "produkty/base.html" %}
+
+{% block title %}Zamiana marka ↔ grupa{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Zamiana: marka ↔ grupa towarowa</h2>
+    <div class="alert alert-warning">
+        <i class="fas fa-triangle-exclamation me-1"></i>
+        Narzędzie do naprawy błędnych importów, gdzie marka i grupa trafiły w odwrotne pola
+        (np. <code>marka=COOLING, grupa=BEKO</code> zamiast <code>marka=BEKO, grupa=COOLING</code>).
+        Zaznacz grupy i/lub marki, których produkty chcesz naprawić, kliknij <strong>Podgląd</strong>,
+        a po sprawdzeniu — <strong>Potwierdź zamianę</strong>. Produkty pasujące do zaznaczonej grupy
+        <u>lub</u> marki zostaną objęte zamianą.
+    </div>
+
+    <form method="post">
+        {% csrf_token %}
+        <div class="row">
+            <div class="col-md-6 mb-3">
+                <div class="card">
+                    <div class="card-header bg-primary text-white">Grupy towarowe</div>
+                    <div class="card-body" style="max-height: 320px; overflow-y: auto;">
+                        {% for g in grupy %}
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" name="grupa" value="{{ g.grupa_towarowa }}"
+                                   id="grupa-{{ forloop.counter }}"
+                                   {% if g.grupa_towarowa in wybrane_grupy %}checked{% endif %}>
+                            <label class="form-check-label" for="grupa-{{ forloop.counter }}">
+                                {{ g.grupa_towarowa }} <span class="badge bg-secondary">{{ g.liczba }}</span>
+                            </label>
+                        </div>
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6 mb-3">
+                <div class="card">
+                    <div class="card-header bg-dark text-white">Marki</div>
+                    <div class="card-body" style="max-height: 320px; overflow-y: auto;">
+                        {% for m in marki %}
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" name="marka" value="{{ m.marka }}"
+                                   id="marka-{{ forloop.counter }}"
+                                   {% if m.marka in wybrane_marki %}checked{% endif %}>
+                            <label class="form-check-label" for="marka-{{ forloop.counter }}">
+                                {{ m.marka }} <span class="badge bg-secondary">{{ m.liczba }}</span>
+                            </label>
+                        </div>
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <button type="submit" name="akcja" value="podglad" class="btn btn-primary">
+            <i class="fas fa-eye me-1"></i> Podgląd
+        </button>
+
+        {% if pokaz_podglad %}
+            <hr>
+            <h4>Podgląd zmian ({{ liczba_podglad }} produktów)</h4>
+            {% if liczba_podglad %}
+            <p class="text-muted small">Sprawdź, czy to na pewno te produkty. Kolumny „po zamianie" pokazują wynik.</p>
+            <button type="submit" name="akcja" value="zamien" class="btn btn-danger mb-3"
+                    onclick="return confirm('Na pewno zamienić markę z grupą dla {{ liczba_podglad }} produktów? Tej operacji nie cofniesz automatycznie.');">
+                <i class="fas fa-right-left me-1"></i> Potwierdź zamianę ({{ liczba_podglad }})
+            </button>
+            <div class="table-responsive">
+                <table class="table table-sm table-bordered table-striped">
+                    <thead class="table-dark">
+                        <tr>
+                            <th>Model</th>
+                            <th>Marka (teraz)</th>
+                            <th>Grupa (teraz)</th>
+                            <th class="text-success">Marka (po zamianie)</th>
+                            <th class="text-success">Grupa (po zamianie)</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for p in podglad %}
+                        <tr>
+                            <td>{{ p.model }}</td>
+                            <td>{{ p.marka }}</td>
+                            <td>{{ p.grupa_towarowa }}</td>
+                            <td class="text-success"><strong>{{ p.grupa_towarowa }}</strong></td>
+                            <td class="text-success"><strong>{{ p.marka }}</strong></td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            {% else %}
+            <p class="text-muted">Żaden produkt nie pasuje do zaznaczonych grup/marek.</p>
+            {% endif %}
+        {% endif %}
+    </form>
+</div>
+{% endblock %}

--- a/produkty/tests_smoke.py
+++ b/produkty/tests_smoke.py
@@ -55,3 +55,38 @@ class SmokeRenderTestCase(TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.context["postep"], 2)
         self.assertTrue(r.context["ma_sprzedaz_historyczna"])
+
+
+class ZamianaMarkaGrupaTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="adm", password="pass", is_staff=True)
+        self.client = Client()
+        self.client.login(username="adm", password="pass")
+        # zle zaimportowany produkt: marka i grupa zamienione miejscami
+        self.p = Produkt.objects.create(model="ZLE1", stawka=Decimal("10"), grupa_towarowa="BEKO", marka="COOLING")
+        # poprawny produkt - nie powinien zostac ruszony
+        self.ok = Produkt.objects.create(model="OK1", stawka=Decimal("10"), grupa_towarowa="AGD", marka="WHIRLPOOL")
+
+    def test_get_renders(self):
+        r = self.client.get(reverse("produkty:zamiana_marka_grupa"))
+        self.assertEqual(r.status_code, 200)
+        self.assertNotIn("pokaz_podglad", r.context)
+
+    def test_preview_does_not_mutate(self):
+        r = self.client.post(reverse("produkty:zamiana_marka_grupa"), {"akcja": "podglad", "grupa": ["BEKO"]})
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.context["liczba_podglad"], 1)
+        self.p.refresh_from_db()
+        self.assertEqual(self.p.marka, "COOLING")  # bez zmian
+        self.assertEqual(self.p.grupa_towarowa, "BEKO")
+
+    def test_swap_applies(self):
+        r = self.client.post(reverse("produkty:zamiana_marka_grupa"), {"akcja": "zamien", "grupa": ["BEKO"]})
+        self.assertEqual(r.status_code, 302)
+        self.p.refresh_from_db()
+        self.assertEqual(self.p.marka, "BEKO")
+        self.assertEqual(self.p.grupa_towarowa, "COOLING")
+        # niezaznaczony produkt bez zmian
+        self.ok.refresh_from_db()
+        self.assertEqual(self.ok.marka, "WHIRLPOOL")
+        self.assertEqual(self.ok.grupa_towarowa, "AGD")

--- a/produkty/urls.py
+++ b/produkty/urls.py
@@ -6,6 +6,7 @@ app_name = 'produkty'  # Dodaj to, aby ustawić namespace dla aplikacji
 urlpatterns = [
     path('produkty/', views.lista_produktow, name='lista_produktow'),
     path('produkty/grupy-marki/', views.grupy_marki_przeglad, name='grupy_marki'),
+    path('produkty/zamiana-marka-grupa/', views.zamiana_marka_grupa, name='zamiana_marka_grupa'),
     path('produkty/edit/<int:product_id>/', views.product_edit, name='product_edit'),
     path('', views.home, name='home'),
     path('import/', views.import_excel, name='import_excel'),

--- a/produkty/views.py
+++ b/produkty/views.py
@@ -8,7 +8,7 @@ from zipfile import BadZipFile
 from decimal import Decimal, InvalidOperation
 import logging
 from django.utils import timezone
-from django.db.models import Sum, Count, F
+from django.db.models import Sum, Count, F, Q
 from collections import defaultdict
 from datetime import timedelta, datetime
 from rapidfuzz import fuzz, process 
@@ -1411,6 +1411,58 @@ def grupy_marki_przeglad(request):
         'liczba_marek': marki.count(),
     }
     return render(request, 'produkty/grupy_marki.html', context)
+
+@staff_member_required
+def zamiana_marka_grupa(request):
+    """Narzedzie admina do masowej zamiany pol marka <-> grupa_towarowa.
+    Czesty problem importu: produkt zapisuje sie jako marka='COOLING',
+    grupa='BEKO' zamiast odwrotnie. Uzytkownik zaznacza grupy i/lub marki,
+    widzi podglad, a dopiero potem potwierdza zamiane."""
+    grupy = (
+        Produkt.objects.exclude(grupa_towarowa__isnull=True).exclude(grupa_towarowa='')
+        .values('grupa_towarowa').annotate(liczba=Count('id')).order_by('grupa_towarowa')
+    )
+    marki = (
+        Produkt.objects.exclude(marka__isnull=True).exclude(marka='')
+        .values('marka').annotate(liczba=Count('id')).order_by('marka')
+    )
+    context = {'grupy': grupy, 'marki': marki}
+
+    if request.method == 'POST':
+        wybrane_grupy = request.POST.getlist('grupa')
+        wybrane_marki = request.POST.getlist('marka')
+        akcja = request.POST.get('akcja')
+
+        if not wybrane_grupy and not wybrane_marki:
+            messages.error(request, "Nie zaznaczono żadnej grupy ani marki.")
+            return render(request, 'produkty/zamiana_marka_grupa.html', context)
+
+        # Produkty pasujace po WYBRANEJ grupie LUB po wybranej marce.
+        q = Q()
+        if wybrane_grupy:
+            q |= Q(grupa_towarowa__in=wybrane_grupy)
+        if wybrane_marki:
+            q |= Q(marka__in=wybrane_marki)
+        produkty_do_zmiany = Produkt.objects.filter(q).order_by('model')
+
+        context['wybrane_grupy'] = wybrane_grupy
+        context['wybrane_marki'] = wybrane_marki
+
+        if akcja == 'zamien':
+            count = 0
+            for p in produkty_do_zmiany:
+                p.marka, p.grupa_towarowa = p.grupa_towarowa, p.marka
+                p.save(update_fields=['marka', 'grupa_towarowa'])
+                count += 1
+            messages.success(request, f"Zamieniono markę z grupą towarową dla {count} produktów.")
+            return redirect('produkty:zamiana_marka_grupa')
+
+        # akcja == 'podglad'
+        context['pokaz_podglad'] = True
+        context['podglad'] = produkty_do_zmiany
+        context['liczba_podglad'] = produkty_do_zmiany.count()
+
+    return render(request, 'produkty/zamiana_marka_grupa.html', context)
 
 @login_required
 def product_edit(request, product_id):


### PR DESCRIPTION
## Cel

Narzędzie admina do masowej naprawy błędnych importów, gdzie **marka** i **grupa towarowa** trafiły w odwrotne pola (np. `marka=COOLING, grupa=BEKO` zamiast `marka=BEKO, grupa=COOLING`). Zamiast poprawiać po 100–200 produktów ręcznie — jedna operacja z podglądem.

> Uwaga: ta gałąź jest wystawiona na `main` i zawiera też commity z PR #16 (porządki) i PR #17 (usprawnienia listy produktów), bo na nich bazuje. Zalecana kolejność scalania: #16 → #17 → ten PR. Scalając sam ten PR i tak dostajesz całość.

## Co robi

- Nowy widok **staff-only** (Admin → „Zamiana marka ↔ grupa").
- Zaznaczasz grupy i/lub marki, których produkty chcesz naprawić (produkty pasujące do zaznaczonej grupy **lub** marki).
- **Krok 1 — Podgląd:** tabela „teraz" vs „po zamianie" + liczba produktów. Nic nie jest zapisywane.
- **Krok 2 — Potwierdź zamianę:** dodatkowe pytanie „na pewno?", dopiero potem zamiana pól `marka` ↔ `grupa_towarowa` dla dopasowanych produktów.

## Bezpieczeństwo
- Dwuetapowy przepływ (podgląd → potwierdzenie) — nic nie zmienia się przez przypadek.
- Operacja dotyka wyłącznie zaznaczonych grup/marek; pozostałe produkty pozostają nietknięte.

## Testy
`python manage.py test` — **23/23 przechodzi**. Nowe testy (`tests_smoke.py`): podgląd nie modyfikuje danych, potwierdzenie zamienia tylko zaznaczone produkty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
