### PR TITLE
feat: prowizja w historii produktu, laczenie duplikatow, nawigacja polecanych

### DIFF
--- a/produkty/templates/produkty/base.html
+++ b/produkty/templates/produkty/base.html
@@ -97,6 +97,7 @@
                         <li><a href="{% url 'produkty:import_excel' %}">Import produktów</a></li>
                         <li><a href="{% url 'produkty:grupy_marki' %}">Grupy i marki (przegląd)</a></li>
                         <li><a href="{% url 'produkty:zamiana_marka_grupa' %}">Zamiana marka ↔ grupa</a></li>
+                        <li><a href="{% url 'produkty:polacz_produkty' %}">Połącz duplikaty produktów</a></li>
                         <li><a href="{% url 'produkty:konta_lista' %}">Zarządzanie kontami</a></li>
                         <li><a href="{% url 'produkty:wyciagnij_liste_modeli' %}">Wyciągnij listę modeli</a></li>
                         <li><a href="{% url 'produkty:delete_sales_for_day' %}">Usuń sprzedaż z dnia</a></li>

--- a/produkty/templates/produkty/historia_sprzedazy_produktu.html
+++ b/produkty/templates/produkty/historia_sprzedazy_produktu.html
@@ -9,9 +9,12 @@
     </div>
 
     <div class="card shadow-sm mb-4">
-        <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
+        <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center flex-wrap gap-2">
             <h3 class="mb-0">Historia sprzedaży: {{ produkt.model }} ({{ produkt.marka }})</h3>
-            <span class="badge bg-light text-dark fs-5">Zaraportowano łącznie: {{ suma_sztuk }} szt.</span>
+            <div class="d-flex gap-2 flex-wrap">
+                <span class="badge bg-light text-dark fs-6">Sztuk łącznie: {{ suma_sztuk }}</span>
+                <span class="badge bg-success fs-6">Prowizja łącznie: {{ suma_prowizji|floatformat:2 }} PLN</span>
+            </div>
         </div>
         <div class="card-body">
             {% if sprzedaz_list %}
@@ -31,7 +34,10 @@
                             <td>{{ sprzedaz.data_sprzedazy }}</td>
                             <td><strong>{{ sprzedaz.liczba_sztuk }}</strong></td>
                             <td>{% if sprzedaz.zadanie %}{{ sprzedaz.zadanie.nazwa }}{% else %}-{% endif %}</td>
-                            <td>{{ sprzedaz.prowizja }} PLN</td>
+                            <td>
+                                {{ sprzedaz.prowizja_za_sztuke|floatformat:2 }} PLN
+                                {% if sprzedaz.prowizja %}<span class="badge bg-warning text-dark ms-1" title="w tym bonus z zadania">+{{ sprzedaz.prowizja|floatformat:2 }} bonus</span>{% endif %}
+                            </td>
                         </tr>
                         {% endfor %}
                     </tbody>

--- a/produkty/templates/produkty/polacz_produkty.html
+++ b/produkty/templates/produkty/polacz_produkty.html
@@ -1,0 +1,73 @@
+{% extends "produkty/base.html" %}
+
+{% block title %}Połącz duplikaty produktów{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Połącz duplikaty produktów</h2>
+    <div class="alert alert-info">
+        <i class="fas fa-circle-info me-1"></i>
+        Narzędzie łączy dwa wpisy tego samego produktu (np. z literówką lub niepełną nazwą).
+        Cała historia sprzedaży (oraz przypisania do zadań, funkcji i mapy) zostanie
+        <strong>przeniesiona z produktu źródłowego na docelowy</strong>, a źródłowy zostanie usunięty.
+        Historia nie ginie — zmienia tylko właściciela.
+    </div>
+
+    <form method="post">
+        {% csrf_token %}
+        <div class="row">
+            <div class="col-md-6 mb-3">
+                <label class="form-label"><strong>Produkt źródłowy</strong> (błędny — zostanie usunięty)</label>
+                <select name="source" class="form-select" required>
+                    <option value="">— wybierz —</option>
+                    {% for p in produkty %}
+                    <option value="{{ p.id }}" {% if source and p.id == source.id %}selected{% endif %}>
+                        {{ p.model }} ({{ p.marka }}) — {{ p.liczba_sprzedazy }} sprzedaży
+                    </option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="col-md-6 mb-3">
+                <label class="form-label"><strong>Produkt docelowy</strong> (poprawny — zostaje)</label>
+                <select name="target" class="form-select" required>
+                    <option value="">— wybierz —</option>
+                    {% for p in produkty %}
+                    <option value="{{ p.id }}" {% if target and p.id == target.id %}selected{% endif %}>
+                        {{ p.model }} ({{ p.marka }}) — {{ p.liczba_sprzedazy }} sprzedaży
+                    </option>
+                    {% endfor %}
+                </select>
+            </div>
+        </div>
+
+        <button type="submit" name="akcja" value="podglad" class="btn btn-primary">
+            <i class="fas fa-eye me-1"></i> Podgląd
+        </button>
+
+        {% if pokaz_podglad %}
+            <hr>
+            <h4>Podgląd połączenia</h4>
+            <table class="table table-bordered w-auto">
+                <tr>
+                    <th>Źródłowy (do usunięcia)</th>
+                    <td>{{ source.model }} ({{ source.marka }})</td>
+                    <td><span class="badge bg-secondary">{{ source_sprzedaz }} sprzedaży</span></td>
+                </tr>
+                <tr>
+                    <th>Docelowy (zostaje)</th>
+                    <td>{{ target.model }} ({{ target.marka }})</td>
+                    <td><span class="badge bg-secondary">{{ target_sprzedaz }} sprzedaży</span></td>
+                </tr>
+                <tr class="table-success">
+                    <th>Po połączeniu docelowy będzie miał</th>
+                    <td colspan="2"><strong>{{ target.model }}</strong>: {{ source_sprzedaz }} + {{ target_sprzedaz }} sprzedaży</td>
+                </tr>
+            </table>
+            <button type="submit" name="akcja" value="polacz" class="btn btn-danger"
+                    onclick="return confirm('Połączyć „{{ source.model }}” w „{{ target.model }}”? Źródłowy zostanie usunięty, a jego {{ source_sprzedaz }} sprzedaży przeniesione.');">
+                <i class="fas fa-code-merge me-1"></i> Potwierdź połączenie
+            </button>
+        {% endif %}
+    </form>
+</div>
+{% endblock %}

--- a/produkty/templates/produkty/polecane_modele.html
+++ b/produkty/templates/produkty/polecane_modele.html
@@ -39,6 +39,16 @@
     </div>
 
     {% if recommendations %}
+        <!-- Szybki wybór grupy (wygodne przy wielu grupach) -->
+        <div class="mb-3">
+            <label for="groupJump" class="form-label fw-bold small mb-1"><i class="fas fa-list me-1"></i>Przejdź do grupy produktowej:</label>
+            <select id="groupJump" class="form-select" onchange="showGroup(this.value)">
+                {% for group, brands in recommendations %}
+                <option value="{{ group|slugify }}">{{ group }}</option>
+                {% endfor %}
+            </select>
+        </div>
+
         <!-- Product Group Tabs -->
         <div class="group-tabs-scroll-container mb-4">
             <div class="group-tabs d-flex gap-2">
@@ -482,6 +492,12 @@
         });
         if (targetBtn) {
             targetBtn.classList.add('active');
+            targetBtn.scrollIntoView({ block: 'nearest', inline: 'center', behavior: 'smooth' });
+        }
+        // Synchronizuj liste rozwijana
+        const jump = document.getElementById('groupJump');
+        if (jump && jump.value !== groupId) {
+            jump.value = groupId;
         }
     }
 </script>

--- a/produkty/tests_smoke.py
+++ b/produkty/tests_smoke.py
@@ -206,3 +206,48 @@ class ProductDeleteTestCase(TestCase):
         self.assertEqual(r2.status_code, 302)
         self.assertFalse(Produkt.objects.filter(id=p.id).exists())
         self.assertEqual(Sprzedaz.objects.filter(produkt_id=p.id).count(), 0)
+
+
+class HistoriaProwizjaTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="hist", password="pass", is_staff=True)
+        self.client = Client()
+        self.client.login(username="hist", password="pass")
+
+    def test_prowizja_liczona_ze_stawki(self):
+        p = Produkt.objects.create(model="P60", stawka=Decimal("60"), grupa_towarowa="X", marka="WHIRLPOOL")
+        Sprzedaz.objects.create(produkt=p, liczba_sztuk=1, data_sprzedazy=date.today())  # prowizja=0
+        Sprzedaz.objects.create(produkt=p, liczba_sztuk=1, data_sprzedazy=date.today(), prowizja=Decimal("20"))
+        r = self.client.get(reverse("produkty:historia_sprzedazy_produktu", args=[p.id]))
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.context["suma_prowizji"], Decimal("140"))  # 60 + (60+20)
+        za_sztuke = sorted(s.prowizja_za_sztuke for s in r.context["sprzedaz_list"])
+        self.assertEqual(za_sztuke, [Decimal("60"), Decimal("80")])
+
+
+class PolaczProduktyTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="mrg", password="pass", is_staff=True)
+        self.client = Client()
+        self.client.login(username="mrg", password="pass")
+        self.src = Produkt.objects.create(model="WH8IA15AM3TUS0X", stawka=Decimal("0"), grupa_towarowa="X", marka="WHIRLPOOL")
+        self.tgt = Produkt.objects.create(model="WH8IA15AM3TUS0", stawka=Decimal("60"), grupa_towarowa="X", marka="WHIRLPOOL")
+        Sprzedaz.objects.create(produkt=self.src, liczba_sztuk=1, data_sprzedazy=date.today())
+        Sprzedaz.objects.create(produkt=self.src, liczba_sztuk=1, data_sprzedazy=date.today())
+
+    def test_podglad_nie_laczy(self):
+        r = self.client.post(reverse("produkty:polacz_produkty"), {"akcja": "podglad", "source": self.src.id, "target": self.tgt.id})
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.context["source_sprzedaz"], 2)
+        self.assertTrue(Produkt.objects.filter(id=self.src.id).exists())
+
+    def test_polaczenie_przenosi_sprzedaz(self):
+        r = self.client.post(reverse("produkty:polacz_produkty"), {"akcja": "polacz", "source": self.src.id, "target": self.tgt.id})
+        self.assertEqual(r.status_code, 302)
+        self.assertFalse(Produkt.objects.filter(id=self.src.id).exists())
+        self.assertEqual(Sprzedaz.objects.filter(produkt=self.tgt).count(), 2)
+
+    def test_ten_sam_produkt_odrzucony(self):
+        r = self.client.post(reverse("produkty:polacz_produkty"), {"akcja": "polacz", "source": self.src.id, "target": self.src.id})
+        self.assertEqual(r.status_code, 200)
+        self.assertTrue(Produkt.objects.filter(id=self.src.id).exists())

--- a/produkty/urls.py
+++ b/produkty/urls.py
@@ -17,6 +17,7 @@ urlpatterns = [
     path('mapa/miejsce/<int:miejsce_id>/usun/', views.miejsce_usun, name='miejsce_usun'),
     path('produkty/edit/<int:product_id>/', views.product_edit, name='product_edit'),
     path('produkty/delete/<int:product_id>/', views.product_delete, name='product_delete'),
+    path('produkty/polacz/', views.polacz_produkty, name='polacz_produkty'),
     path('', views.home, name='home'),
     path('import/', views.import_excel, name='import_excel'),
     path('test/', views.test_template, name='test_template'),

--- a/produkty/views.py
+++ b/produkty/views.py
@@ -1626,6 +1626,57 @@ def product_delete(request, product_id):
         'liczba_sprzedazy': liczba_sprzedazy,
     })
 
+@staff_member_required
+def polacz_produkty(request):
+    """Laczenie duplikatow: przenosi historie sprzedazy (oraz przypisania do
+    zadan, funkcji i mapy) z produktu zrodlowego na docelowy, po czym usuwa
+    zrodlowy. Dwuetapowo: podglad -> potwierdzenie."""
+    produkty = Produkt.objects.annotate(liczba_sprzedazy=Count('sprzedaz')).order_by('model')
+    context = {'produkty': produkty}
+
+    if request.method == 'POST':
+        source_id = request.POST.get('source')
+        target_id = request.POST.get('target')
+        akcja = request.POST.get('akcja')
+
+        if not source_id or not target_id:
+            messages.error(request, "Wybierz oba produkty (źródłowy i docelowy).")
+            return render(request, 'produkty/polacz_produkty.html', context)
+        if source_id == target_id:
+            messages.error(request, "Produkt źródłowy i docelowy muszą być różne.")
+            return render(request, 'produkty/polacz_produkty.html', context)
+
+        source = get_object_or_404(Produkt, id=source_id)
+        target = get_object_or_404(Produkt, id=target_id)
+        source_sprzedaz = Sprzedaz.objects.filter(produkt=source).count()
+
+        if akcja == 'polacz':
+            Sprzedaz.objects.filter(produkt=source).update(produkt=target)
+            for z in source.zadania.all():
+                z.produkty.add(target)
+            for f in source.funkcje.all():
+                f.produkty.add(target)
+            MiejsceProduktu.objects.filter(produkt=source).update(produkt=target)
+            source_model = source.model
+            source.delete()
+            messages.success(
+                request,
+                f"Połączono: {source_model} -> {target.model}. "
+                f"Przeniesiono {source_sprzedaz} rekordów sprzedaży, usunięto duplikat."
+            )
+            return redirect('produkty:polacz_produkty')
+
+        # akcja == 'podglad'
+        context.update({
+            'pokaz_podglad': True,
+            'source': source,
+            'target': target,
+            'source_sprzedaz': source_sprzedaz,
+            'target_sprzedaz': Sprzedaz.objects.filter(produkt=target).count(),
+        })
+
+    return render(request, 'produkty/polacz_produkty.html', context)
+
 from .models import Funkcja, Podpowiedz
 
 @login_required
@@ -1648,12 +1699,21 @@ def podpowiedz_szczegoly(request, podpowiedz_id):
 @login_required
 def historia_sprzedazy_produktu(request, produkt_id):
     produkt = get_object_or_404(Produkt, id=produkt_id)
-    sprzedaz_list = Sprzedaz.objects.filter(produkt=produkt).order_by('-data_sprzedazy')
-    suma_sztuk = sprzedaz_list.aggregate(total=Sum('liczba_sztuk'))['total'] or 0
+    sprzedaz_list = list(Sprzedaz.objects.filter(produkt=produkt).order_by('-data_sprzedazy'))
+    suma_sztuk = 0
+    suma_prowizji = Decimal('0.00')
+    stawka = produkt.stawka or Decimal('0.00')
+    for s in sprzedaz_list:
+        # Prowizja za 1 szt. = bazowa stawka produktu + ewentualny bonus z zadania.
+        s.prowizja_za_sztuke = stawka + (s.prowizja or Decimal('0.00'))
+        s.prowizja_calkowita = s.liczba_sztuk * stawka + (s.prowizja or Decimal('0.00'))
+        suma_sztuk += s.liczba_sztuk
+        suma_prowizji += s.prowizja_calkowita
     return render(request, 'produkty/historia_sprzedazy_produktu.html', {
         'produkt': produkt,
         'sprzedaz_list': sprzedaz_list,
-        'suma_sztuk': suma_sztuk
+        'suma_sztuk': suma_sztuk,
+        'suma_prowizji': suma_prowizji,
     })
 
 from .forms import UserCreateForm, UserEditForm


### PR DESCRIPTION
## Cel

Trzy poprawki w obszarze produktów zgłoszone przez użytkownika: błąd prowizji w historii produktu, narzędzie łączenia duplikatów, wygodniejsza nawigacja grup w „Polecanych modelach".

## Co się zmieniło

### 1. Historia produktu — poprawna prowizja
Kolumna „Prowizja (za 1 szt.)" pokazywała pole `prowizja` (bonus z zadań MIX, domyślnie 0) zamiast stawki produktu — stąd 0,00 PLN mimo prowizji. Teraz:
- pokazuje **prowizję za sztukę = stawka produktu + ewentualny bonus z zadania**,
- w nagłówku dochodzi **łączna zarobiona prowizja**.

### 2. Łączenie duplikatów produktów (admin)
Nowe narzędzie (Admin → „Połącz duplikaty produktów"): wybierasz produkt **źródłowy** (błędny/niepełna nazwa) i **docelowy** (poprawny). Po podglądzie i potwierdzeniu cała historia sprzedaży (oraz przypisania do zadań, funkcji i mapy) zostaje **przeniesiona** na docelowy, a źródłowy usunięty. Historia nie ginie — zmienia właściciela.

### 3. Polecane modele — szybki wybór grupy
Nad zakładkami grup doszła **lista rozwijana „Przejdź do grupy produktowej"** — zamiast przewijać poziomy pasek zakładek, wybierasz grupę z listy (zakładka aktywnej grupy sama się przewija do widoku). Nawigacja do zmywarek/pralek jest teraz natychmiastowa.

## Testy
`python manage.py test` — pełny zestaw przechodzi. Nowe testy: prowizja liczona ze stawki (+bonus), podgląd łączenia nie modyfikuje danych, łączenie przenosi sprzedaż i usuwa duplikat, odrzucenie łączenia produktu z samym sobą.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
