### PR TITLE
fix: widocznosc wszystkich zadan w podsumowaniu + rozbicie zarobku (sprzedaz / zadania / suma)

### DIFF
--- a/produkty/templates/produkty/podsumowanie_sprzedazy.html
+++ b/produkty/templates/produkty/podsumowanie_sprzedazy.html
@@ -51,7 +51,40 @@
 </div>
 
 <p><strong>Liczba sprzedanych sztuk:</strong> {{ liczba_sztuk }}</p>
-<p><strong>Całkowita prowizja:</strong> {{ calkowita_prowizja }} PLN</p>
+
+<!-- Rozbicie zarobku: sprzedaż / zadania / suma -->
+<div class="row mb-4">
+    <div class="col-md-4 mb-2">
+        <div class="card h-100">
+            <div class="card-body py-3">
+                <h6 class="text-uppercase text-muted mb-1" style="font-size:0.75rem;">Ze sprzedaży</h6>
+                <div class="small text-muted mb-2">stawki bazowe modeli</div>
+                <div class="fs-4 fw-bold">{{ prowizja_ze_sprzedazy|floatformat:2 }} PLN</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4 mb-2">
+        <div class="card border-warning h-100">
+            <div class="card-body py-3">
+                <h6 class="text-uppercase text-muted mb-1" style="font-size:0.75rem;">Z zadań</h6>
+                <div class="small text-muted mb-2">
+                    premie progowe: {{ premie_progowe|floatformat:2 }} PLN<br>
+                    bonusy z mnożników: {{ bonus_mnoznikowy|floatformat:2 }} PLN
+                </div>
+                <div class="fs-4 fw-bold text-warning-emphasis">{{ prowizja_z_zadan|floatformat:2 }} PLN</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4 mb-2">
+        <div class="card border-success h-100 bg-light">
+            <div class="card-body py-3">
+                <h6 class="text-uppercase text-muted mb-1" style="font-size:0.75rem;">Razem zarobione</h6>
+                <div class="small text-muted mb-2">sprzedaż + zadania</div>
+                <div class="fs-3 fw-bold text-success">{{ suma_calkowita|floatformat:2 }} PLN</div>
+            </div>
+        </div>
+    </div>
+</div>
 
 <!-- Podział na grupy targetowe -->
 <div class="row mb-4">
@@ -214,23 +247,64 @@
 {% endif %}
 {% if task_rewards %}
 <h2>Rozliczenia zadań</h2>
-<table>
-    <thead>
+<p class="text-muted small">
+    Zadania aktywne w wybranym okresie. Wykonane są na górze.
+    Zadania typu „Mix mnożnik” zarabiają przez podniesioną stawkę przy każdej sprzedaży
+    (kolumna „Bonus”), a pozostałe przez premię za osiągnięty próg.
+</p>
+<table class="table table-striped align-middle">
+    <thead class="table-dark">
         <tr>
             <th>Zadanie</th>
-            <th>Sprzedane sztuki</th>
-            <th>Premia</th>
+            <th>Typ</th>
+            <th class="text-center">Status</th>
+            <th class="text-center">Sprzedane / próg</th>
+            <th class="text-end">Premia</th>
+            <th class="text-end">Bonus</th>
+            <th class="text-end">Zarobek</th>
         </tr>
     </thead>
     <tbody>
         {% for r in task_rewards %}
-        <tr>
-            <td>{{ r.nazwa }}</td>
-            <td>{{ r.sprzedane }}</td>
-            <td>{{ r.premia }} PLN</td>
+        <tr {% if r.wykonane %}class="table-success"{% endif %}>
+            <td>
+                <a href="{% url 'produkty:szczegoly_zadania' r.id %}">{{ r.nazwa }}</a>
+                <br><small class="text-muted">{{ r.data_start }} – {{ r.data_koniec }}</small>
+            </td>
+            <td><small>{{ r.typ }}</small></td>
+            <td class="text-center">
+                {% if r.wykonane %}
+                    <span class="badge bg-success">Wykonane</span>
+                {% else %}
+                    <span class="badge bg-secondary">W trakcie</span>
+                {% endif %}
+            </td>
+            <td class="text-center">
+                <strong>{{ r.sprzedane }}</strong>
+                {% if r.prog_osiagniety %}
+                    / {{ r.prog_osiagniety }}
+                {% elif r.prog_mix %}
+                    / {{ r.prog_mix }}
+                {% elif r.prog_2 %}
+                    / {{ r.prog_1 }} lub {{ r.prog_2 }}
+                {% elif r.prog_1 %}
+                    / {{ r.prog_1 }}
+                {% endif %}
+            </td>
+            <td class="text-end">{% if r.premia %}{{ r.premia|floatformat:2 }} PLN{% else %}<span class="text-muted">—</span>{% endif %}</td>
+            <td class="text-end">{% if r.bonus_mnoznik %}{{ r.bonus_mnoznik|floatformat:2 }} PLN{% else %}<span class="text-muted">—</span>{% endif %}</td>
+            <td class="text-end"><strong>{% if r.zarobek %}{{ r.zarobek|floatformat:2 }} PLN{% else %}—{% endif %}</strong></td>
         </tr>
         {% endfor %}
     </tbody>
+    <tfoot>
+        <tr class="fw-bold">
+            <td colspan="4" class="text-end">Razem z zadań:</td>
+            <td class="text-end">{{ premie_progowe|floatformat:2 }} PLN</td>
+            <td class="text-end">{{ bonus_mnoznikowy|floatformat:2 }} PLN</td>
+            <td class="text-end text-success">{{ prowizja_z_zadan|floatformat:2 }} PLN</td>
+        </tr>
+    </tfoot>
 </table>
 {% endif %}
 {% endblock %}

--- a/produkty/tests_podsumowanie.py
+++ b/produkty/tests_podsumowanie.py
@@ -1,0 +1,129 @@
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth.models import User
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from .models import Produkt, Sprzedaz, Zadanie
+
+
+class PodsumowanieZadaniaKasaTestCase(TestCase):
+    """Rozliczenie zadan w podsumowaniu sprzedazy: widocznosc wszystkich zadan
+    oraz rozbicie zarobku na sprzedaz / zadania / sume."""
+
+    OKRES = "?data_od=2026-07-01&data_do=2026-07-31"
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="sprzedawca", password="pass")
+        self.client = Client()
+        self.client.login(username="sprzedawca", password="pass")
+
+        self.p = Produkt.objects.create(model="PRALKA1", stawka=Decimal("10"), grupa_towarowa="PRALKI", marka="BEKO")
+        # baza = 3*10 + 2*10 = 50; bonus mnoznikowy zapisany przy sprzedazy = 15
+        Sprzedaz.objects.create(produkt=self.p, liczba_sztuk=3, data_sprzedazy=date(2026, 7, 10))
+        Sprzedaz.objects.create(produkt=self.p, liczba_sztuk=2, data_sprzedazy=date(2026, 7, 11),
+                                prowizja=Decimal("15"))
+
+    def _zadanie(self, nazwa, **kwargs):
+        z = Zadanie.objects.create(
+            nazwa=nazwa,
+            data_start=date(2026, 7, 1),
+            data_koniec=date(2026, 7, 31),
+            **kwargs,
+        )
+        z.produkty.add(self.p)
+        return z
+
+    def _podsumowanie(self):
+        return self.client.get(reverse("produkty:podsumowanie_sprzedazy") + self.OKRES)
+
+    def test_zadanie_mix_mnoznik_jest_widoczne(self):
+        """Wczesniej zadania typu Mix mnoznik nigdy sie nie pokazywaly,
+        bo nie maja premii progowej."""
+        self._zadanie("Mnoznik pralki", typ=Zadanie.Typ.MIX_MNOZNIK,
+                      prog_mix=4, mnoznik_mix=Decimal("1.5"))
+        r = self._podsumowanie()
+        self.assertEqual(r.status_code, 200)
+        nazwy = [t["nazwa"] for t in r.context["task_rewards"]]
+        self.assertIn("Mnoznik pralki", nazwy)
+        wpis = r.context["task_rewards"][0]
+        self.assertTrue(wpis["wykonane"])
+        self.assertEqual(wpis["bonus_mnoznik"], Decimal("15"))
+
+    def test_wszystkie_wykonane_zadania_sa_widoczne(self):
+        """Sedno zgloszenia: pokazywalo sie tylko jedno zadanie."""
+        self._zadanie("Progowe z premia", prog_1=5, prog_1_premia=Decimal("100"))
+        self._zadanie("Mnoznikowe", typ=Zadanie.Typ.MIX_MNOZNIK, prog_mix=4, mnoznik_mix=Decimal("1.5"))
+        self._zadanie("Progowe bez kwoty", prog_1=5)  # wykonane, ale premia nieustawiona
+
+        r = self._podsumowanie()
+        wykonane = [t["nazwa"] for t in r.context["task_rewards"] if t["wykonane"]]
+        self.assertEqual(len(wykonane), 3)
+        self.assertIn("Progowe z premia", wykonane)
+        self.assertIn("Mnoznikowe", wykonane)
+        self.assertIn("Progowe bez kwoty", wykonane)
+
+    def test_zadanie_niewykonane_tez_widoczne_ale_oznaczone(self):
+        self._zadanie("Daleko do celu", prog_1=999, prog_1_premia=Decimal("500"))
+        r = self._podsumowanie()
+        wpis = [t for t in r.context["task_rewards"] if t["nazwa"] == "Daleko do celu"][0]
+        self.assertFalse(wpis["wykonane"])
+        self.assertEqual(wpis["premia"], Decimal("0.00"))
+        self.assertEqual(wpis["sprzedane"], 5)
+
+    def test_wykonane_sortowane_na_gore(self):
+        self._zadanie("Niewykonane", prog_1=999, prog_1_premia=Decimal("500"))
+        self._zadanie("Wykonane", prog_1=5, prog_1_premia=Decimal("100"))
+        r = self._podsumowanie()
+        self.assertEqual(r.context["task_rewards"][0]["nazwa"], "Wykonane")
+
+    def test_rozbicie_kwoty_sprzedaz_zadania_suma(self):
+        self._zadanie("Progowe", prog_1=5, prog_1_premia=Decimal("100"))
+        self._zadanie("Mnoznikowe", typ=Zadanie.Typ.MIX_MNOZNIK, prog_mix=4, mnoznik_mix=Decimal("1.5"))
+
+        r = self._podsumowanie()
+        ctx = r.context
+        self.assertEqual(ctx["prowizja_ze_sprzedazy"], Decimal("50"))    # 3*10 + 2*10
+        self.assertEqual(ctx["bonus_mnoznikowy"], Decimal("15"))         # pole prowizja przy sprzedazy
+        self.assertEqual(ctx["premie_progowe"], Decimal("100"))
+        self.assertEqual(ctx["prowizja_z_zadan"], Decimal("115"))        # 15 + 100
+        self.assertEqual(ctx["suma_calkowita"], Decimal("165"))          # 50 + 115
+
+    def test_brak_podwojnego_liczenia_bonusu(self):
+        """Dwa zadania mnoznikowe na tych samych produktach nie moga zdublowac
+        bonusu w sumie calkowitej."""
+        self._zadanie("Mnoznik A", typ=Zadanie.Typ.MIX_MNOZNIK, prog_mix=4, mnoznik_mix=Decimal("1.5"))
+        self._zadanie("Mnoznik B", typ=Zadanie.Typ.MIX_MNOZNIK, prog_mix=4, mnoznik_mix=Decimal("2"))
+
+        ctx = self._podsumowanie().context
+        self.assertEqual(ctx["bonus_mnoznikowy"], Decimal("15"))   # nie 30
+        self.assertEqual(ctx["suma_calkowita"], Decimal("65"))     # 50 + 15
+
+    def test_suma_zgadza_sie_z_czesciami(self):
+        self._zadanie("Progowe", prog_1=5, prog_1_premia=Decimal("100"))
+        ctx = self._podsumowanie().context
+        self.assertEqual(
+            ctx["suma_calkowita"],
+            ctx["prowizja_ze_sprzedazy"] + ctx["prowizja_z_zadan"],
+        )
+        self.assertEqual(
+            ctx["prowizja_z_zadan"],
+            ctx["bonus_mnoznikowy"] + ctx["premie_progowe"],
+        )
+
+    def test_zadanie_spoza_okresu_nie_liczy_sie(self):
+        z = Zadanie.objects.create(nazwa="Sierpniowe", data_start=date(2026, 8, 1), data_koniec=date(2026, 8, 31),
+                                   prog_1=1, prog_1_premia=Decimal("999"))
+        z.produkty.add(self.p)
+        ctx = self._podsumowanie().context
+        self.assertEqual([t["nazwa"] for t in ctx["task_rewards"]], [])
+        self.assertEqual(ctx["premie_progowe"], Decimal("0.00"))
+
+    def test_wyzszy_prog_ma_pierwszenstwo(self):
+        self._zadanie("Dwa progi", prog_1=3, prog_1_premia=Decimal("50"),
+                      prog_2=5, prog_2_premia=Decimal("120"))
+        ctx = self._podsumowanie().context
+        wpis = ctx["task_rewards"][0]
+        self.assertEqual(wpis["premia"], Decimal("120"))
+        self.assertEqual(wpis["prog_osiagniety"], 5)

--- a/produkty/views.py
+++ b/produkty/views.py
@@ -372,7 +372,8 @@ def podsumowanie_sprzedazy(request):
     # Prowizja = baza (liczba_sztuk * stawka) + bonus z zadan (pole prowizja),
     # spojnie z widokiem dziennym (daily_sales_view).
     sprzedaz_annotated = sprzedaz_qs.annotate(
-        obliczona_prowizja=models.F('liczba_sztuk') * models.F('produkt__stawka') + models.F('prowizja')
+        prowizja_baza=models.F('liczba_sztuk') * models.F('produkt__stawka'),
+        obliczona_prowizja=models.F('liczba_sztuk') * models.F('produkt__stawka') + models.F('prowizja'),
     )
 
     sprzedaz_podsumowanie = (
@@ -399,29 +400,73 @@ def podsumowanie_sprzedazy(request):
             'liczba_sztuk': s['liczba_sztuk']
         }
 
-    # Task rewards computation
+    # ==== Zadania: premie progowe i bonusy mnoznikowe ====
+    # Wczesniej pokazywaly sie tylko zadania z premia progowa > 0, wiec zadania
+    # typu "Mix mnoznik" (bonus naliczany per sprzedaz) nigdy nie byly widoczne,
+    # tak samo jak zadania wykonane, ale bez ustawionej kwoty premii.
+    zakres_od = data_od or data_do
+    zakres_do = data_do or data_od
+
     task_rewards = []
-    if data_od and data_do:
-        tasks = Zadanie.objects.filter(data_start__lte=data_do, data_koniec__gte=data_od)
+    premie_progowe = Decimal("0.00")
+
+    if zakres_od and zakres_do:
+        tasks = Zadanie.objects.filter(
+            data_start__lte=zakres_do, data_koniec__gte=zakres_od
+        ).prefetch_related('produkty')
+
         for task in tasks:
             sales_in_task = Sprzedaz.objects.filter(
                 produkt__in=task.produkty.all(),
                 data_sprzedazy__range=(task.data_start, task.data_koniec)
             )
             total_sold = sales_in_task.aggregate(suma=Sum('liczba_sztuk'))['suma'] or 0
-            
+
             premia = Decimal("0.00")
-            if task.prog_2 and total_sold >= task.prog_2:
-                premia = task.prog_2_premia or Decimal("0.00")
-            elif task.prog_1 and total_sold >= task.prog_1:
-                premia = task.prog_1_premia or Decimal("0.00")
-                
-            if premia > 0:
-                task_rewards.append({
-                    'nazwa': task.nazwa,
-                    'sprzedane': total_sold,
-                    'premia': premia
-                })
+            bonus_mnoznik = Decimal("0.00")
+            prog_osiagniety = None
+            wykonane = False
+
+            if task.typ == Zadanie.Typ.MIX_MNOZNIK:
+                # Bonus tego typu jest juz zapisany przy kazdej sprzedazy (pole prowizja).
+                bonus_mnoznik = sales_in_task.aggregate(s=Sum('prowizja'))['s'] or Decimal("0.00")
+                if task.prog_mix:
+                    wykonane = total_sold >= task.prog_mix
+                    if wykonane:
+                        prog_osiagniety = task.prog_mix
+            else:
+                if task.prog_2 and total_sold >= task.prog_2:
+                    premia = task.prog_2_premia or Decimal("0.00")
+                    prog_osiagniety = task.prog_2
+                    wykonane = True
+                elif task.prog_1 and total_sold >= task.prog_1:
+                    premia = task.prog_1_premia or Decimal("0.00")
+                    prog_osiagniety = task.prog_1
+                    wykonane = True
+
+            premie_progowe += premia
+
+            task_rewards.append({
+                'id': task.id,
+                'nazwa': task.nazwa,
+                'typ': task.get_typ_display(),
+                'sprzedane': total_sold,
+                'prog_1': task.prog_1,
+                'prog_2': task.prog_2,
+                'prog_mix': task.prog_mix,
+                'prog_osiagniety': prog_osiagniety,
+                'premia': premia,
+                'bonus_mnoznik': bonus_mnoznik,
+                'zarobek': premia + bonus_mnoznik,
+                'wykonane': wykonane,
+                'data_start': task.data_start,
+                'data_koniec': task.data_koniec,
+            })
+
+        # Wykonane na gorze, potem wedlug zarobku.
+        task_rewards.sort(key=lambda t: (not t['wykonane'], -t['zarobek'], t['nazwa']))
+
+    zadania_wykonane = [t for t in task_rewards if t['wykonane']]
 
     grupa_beko_marki = list(GRUPA_BEKO_MARKI)
     grupa_whirlpool_marki = list(GRUPA_WHIRLPOOL_MARKI)
@@ -452,8 +497,18 @@ def podsumowanie_sprzedazy(request):
 
     agregaty = sprzedaz_annotated.aggregate(
         calkowita_liczba_sztuk=Sum('liczba_sztuk'),
-        calkowita_prowizja=Sum('obliczona_prowizja')
+        calkowita_prowizja=Sum('obliczona_prowizja'),
+        suma_bazowa=Sum('prowizja_baza'),
+        suma_bonusow=Sum('prowizja'),
     )
+
+    # Rozbicie zarobku: sama sprzedaz vs zadania vs suma.
+    # Bonus mnoznikowy jest zapisany przy sprzedazy (pole prowizja), a premie
+    # progowe licza sie osobno - dzieki temu nic nie jest liczone podwojnie.
+    prowizja_ze_sprzedazy = agregaty['suma_bazowa'] or Decimal("0.00")
+    bonus_mnoznikowy = agregaty['suma_bonusow'] or Decimal("0.00")
+    prowizja_z_zadan = bonus_mnoznikowy + premie_progowe
+    suma_calkowita = prowizja_ze_sprzedazy + prowizja_z_zadan
 
     # Postep targetu hali dla kwartalu obejmujacego wybrany okres.
     postep_targetu = None
@@ -480,6 +535,12 @@ def podsumowanie_sprzedazy(request):
         'postep_targetu': postep_targetu,
         'liczba_sztuk': agregaty['calkowita_liczba_sztuk'] or 0,
         'calkowita_prowizja': agregaty['calkowita_prowizja'] or 0,
+        'prowizja_ze_sprzedazy': prowizja_ze_sprzedazy,
+        'bonus_mnoznikowy': bonus_mnoznikowy,
+        'premie_progowe': premie_progowe,
+        'prowizja_z_zadan': prowizja_z_zadan,
+        'suma_calkowita': suma_calkowita,
+        'zadania_wykonane': zadania_wykonane,
         'data_od': data_od,
         'data_do': data_do,
         'produkt': produkt_nazwa or '',


### PR DESCRIPTION
## Cel

Naprawa rozliczania zadań w podsumowaniu sprzedaży: brakujące wykonane zadania oraz czytelne rozbicie zarobku na sprzedaż i zadania.

## Problem 1 — pokazywało się tylko jedno wykonane zadanie

Stary warunek wyświetlał zadanie **tylko wtedy, gdy premia progowa była większa od zera**:

```python
if premia > 0:
    task_rewards.append(...)
```

Przez to znikały:
- zadania typu **„Mix mnożnik"** — one nie mają premii progowej, bo zarabiają przez podniesioną stawkę zapisywaną przy każdej sprzedaży. Premia zawsze wychodziła 0, więc **nigdy się nie pokazywały**, choćby były wykonane;
- zadania **wykonane, ale bez wpisanej kwoty premii** (sam próg, puste `prog_1_premia`).

### Naprawa
Rozliczenie liczy teraz każdy typ zadania osobno:
- **Mix mnożnik** — wykonanie sprawdzane po `prog_mix`, a zarobek to suma bonusów zapisanych przy sprzedażach tego zadania,
- **pozostałe typy** — premia za najwyższy osiągnięty próg (próg 2 ma pierwszeństwo przed progiem 1).

Tabela pokazuje **wszystkie zadania aktywne w wybranym okresie**, wykonane na górze, z kolumnami: typ, status (Wykonane / W trakcie), sprzedane / próg, premia, bonus i zarobek. Nazwa zadania linkuje do jego szczegółów.

## Problem 2 — brak rozbicia zarobku

Wcześniej „Całkowita prowizja" zawierała bazę i bonusy mnożnikowe, ale **premie progowe nie były do niej wliczane** i wisiały osobno w tabeli. Nie było widać, ile realnie zarobiono łącznie.

### Naprawa
Nad podsumowaniem doszły trzy kafle:

| Kafel | Co zawiera |
|---|---|
| **Ze sprzedaży** | stawki bazowe modeli (`liczba_sztuk × stawka`) |
| **Z zadań** | premie progowe + bonusy z mnożników (obie kwoty rozpisane) |
| **Razem zarobione** | suma obu powyższych |

Tabela zadań ma dodatkowo wiersz podsumowujący („Razem z zadań").

**Brak podwójnego liczenia:** bonus mnożnikowy jest zapisany przy sprzedaży, więc do sumy globalnej wchodzi raz — nawet jeśli ten sam produkt należy do dwóch zadań mnożnikowych (kwota per zadanie w tabeli jest informacyjna).

## Testy
`python manage.py test` — pełny zestaw przechodzi. 9 nowych testów:
- zadanie „Mix mnożnik" jest widoczne i ma policzony bonus,
- wszystkie trzy wykonane zadania są widoczne (sedno zgłoszenia),
- zadanie niewykonane widoczne, ale oznaczone,
- wykonane sortowane na górze,
- rozbicie kwot: 50 ze sprzedaży + 115 z zadań = 165 razem,
- brak podwójnego liczenia bonusu przy dwóch zadaniach mnożnikowych (15, nie 30),
- suma zawsze zgadza się ze swoimi częściami,
- zadanie spoza okresu nie jest liczone,
- wyższy próg ma pierwszeństwo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
