### PR TITLE
fix: edycja premii w zadaniach - brakujace pola formularza kasowaly dane

### DIFF
--- a/produkty/forms.py
+++ b/produkty/forms.py
@@ -15,15 +15,41 @@ class ZadanieForm(forms.ModelForm):
             'produkty': forms.SelectMultiple(attrs={'class': 'form-control', 'size': '10'}),
             'data_start': forms.DateInput(attrs={'class': 'form-control', 'type': 'date'}),
             'data_koniec': forms.DateInput(attrs={'class': 'form-control', 'type': 'date'}),
-            'target': forms.Select(attrs={'class': 'form-control'}),
-            'prog_1': forms.NumberInput(attrs={'class': 'form-control'}),
-            'prog_1_premia': forms.NumberInput(attrs={'class': 'form-control'}),
-            'prog_2': forms.NumberInput(attrs={'class': 'form-control'}),
-            'prog_2_premia': forms.NumberInput(attrs={'class': 'form-control'}),
-            'mnoznik_mix': forms.NumberInput(attrs={'class': 'form-control'}),
-            'prog_mix': forms.NumberInput(attrs={'class': 'form-control'}),
-            'typ': forms.Select(attrs={'class': 'form-control'}),
+            'target': forms.Select(attrs={'class': 'form-select'}),
+            'prog_1': forms.NumberInput(attrs={'class': 'form-control', 'min': 0}),
+            'prog_1_premia': forms.NumberInput(attrs={'class': 'form-control', 'step': '0.01', 'min': 0}),
+            'prog_2': forms.NumberInput(attrs={'class': 'form-control', 'min': 0}),
+            'prog_2_premia': forms.NumberInput(attrs={'class': 'form-control', 'step': '0.01', 'min': 0}),
+            'mnoznik_mix': forms.NumberInput(attrs={'class': 'form-control', 'step': '0.01', 'min': 0}),
+            'prog_mix': forms.NumberInput(attrs={'class': 'form-control', 'min': 0}),
+            'typ': forms.Select(attrs={'class': 'form-select', 'id': 'id_typ'}),
         }
+        labels = {
+            'nazwa': 'Nazwa zadania',
+            'opis': 'Opis',
+            'data_start': 'Data rozpoczęcia',
+            'data_koniec': 'Data zakończenia',
+            'typ': 'Typ zadania',
+            'target': 'Cel liczony wg',
+            'prog_1': 'Próg 1 (szt.)',
+            'prog_1_premia': 'Premia za próg 1 (PLN)',
+            'prog_2': 'Próg 2 (szt.)',
+            'prog_2_premia': 'Premia za próg 2 (PLN)',
+            'prog_mix': 'Próg mix (szt.)',
+            'mnoznik_mix': 'Mnożnik stawki',
+        }
+        help_texts = {
+            'prog_1_premia': 'Kwota wypłacana po osiągnięciu progu 1.',
+            'prog_2_premia': 'Kwota wypłacana po osiągnięciu progu 2 (ma pierwszeństwo przed progiem 1).',
+            'mnoznik_mix': 'Np. 1.5 = stawka podniesiona o 50% po przekroczeniu progu mix.',
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Zadania zapisane przed wprowadzeniem typow moga miec pusty typ -
+        # podstawiamy sensowna wartosc, zeby edycja nie wysypywala walidacji.
+        if not self.initial.get('typ') and not self.data.get('typ'):
+            self.initial['typ'] = Zadanie.Typ.KONKRETNE_MODELE
 
     def clean(self):
         cleaned_data = super().clean()

--- a/produkty/static/produkty/js/zadanie_form.js
+++ b/produkty/static/produkty/js/zadanie_form.js
@@ -76,4 +76,29 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     initialize();
+
+    // Pokazywanie sekcji zaleznie od typu zadania.
+    // Sekcje sa tylko ukrywane (display:none), a nie usuwane z formularza,
+    // wiec zapisane wartosci nie sa kasowane przy zapisie.
+    const typSelect = document.getElementById('id_typ');
+    const sekcjaProgi = document.getElementById('sekcja-progi');
+    const sekcjaMix = document.getElementById('sekcja-mix');
+    const poleMnoznik = document.getElementById('pole-mnoznik');
+
+    function przelaczSekcje() {
+        if (!typSelect) return;
+        const typ = typSelect.value;
+        const pokazProgi = typ !== 'MIX_MNOZNIK';
+        const pokazMix = typ === 'MIX_MNOZNIK' || typ === 'MIX_PROWIZJA';
+        const pokazMnoznik = typ === 'MIX_MNOZNIK';
+
+        if (sekcjaProgi) sekcjaProgi.style.display = pokazProgi ? '' : 'none';
+        if (sekcjaMix) sekcjaMix.style.display = pokazMix ? '' : 'none';
+        if (poleMnoznik) poleMnoznik.style.display = pokazMnoznik ? '' : 'none';
+    }
+
+    if (typSelect) {
+        typSelect.addEventListener('change', przelaczSekcje);
+        przelaczSekcje();
+    }
 });

--- a/produkty/templates/produkty/zadanie_form.html
+++ b/produkty/templates/produkty/zadanie_form.html
@@ -102,16 +102,68 @@
         </div>
         <div style="display:none;">{{ form.produkty }}</div>
 
-        <div class="row mt-3">
+        <hr class="mt-4">
+        <h5 class="mb-3">Rozliczenie zadania</h5>
+
+        <div class="row">
             <div class="col-md-6 mb-3">
-                <label for="{{ form.prog_1.id_for_label }}" class="form-label">{{ form.prog_1.label }}</label>
-                {{ form.prog_1 }}
-                {% if form.prog_1.errors %}<div class="invalid-feedback d-block">{{ form.prog_1.errors }}</div>{% endif %}
+                <label for="{{ form.typ.id_for_label }}" class="form-label">{{ form.typ.label }}</label>
+                {{ form.typ }}
+                <div class="form-text">Od typu zależy, które pola poniżej są brane pod uwagę.</div>
+                {% if form.typ.errors %}<div class="invalid-feedback d-block">{{ form.typ.errors }}</div>{% endif %}
             </div>
             <div class="col-md-6 mb-3">
-                <label for="{{ form.prog_2.id_for_label }}" class="form-label">{{ form.prog_2.label }}</label>
-                {{ form.prog_2 }}
-                {% if form.prog_2.errors %}<div class="invalid-feedback d-block">{{ form.prog_2.errors }}</div>{% endif %}
+                <label for="{{ form.target.id_for_label }}" class="form-label">{{ form.target.label }}</label>
+                {{ form.target }}
+                {% if form.target.errors %}<div class="invalid-feedback d-block">{{ form.target.errors }}</div>{% endif %}
+            </div>
+        </div>
+
+        <!-- Progi z premią: KONKRETNE_MODELE i MIX_PROWIZJA -->
+        <div id="sekcja-progi" class="border rounded p-3 mb-3">
+            <p class="fw-bold mb-2">Progi i premie</p>
+            <div class="row">
+                <div class="col-md-3 mb-3">
+                    <label for="{{ form.prog_1.id_for_label }}" class="form-label">{{ form.prog_1.label }}</label>
+                    {{ form.prog_1 }}
+                    {% if form.prog_1.errors %}<div class="invalid-feedback d-block">{{ form.prog_1.errors }}</div>{% endif %}
+                </div>
+                <div class="col-md-3 mb-3">
+                    <label for="{{ form.prog_1_premia.id_for_label }}" class="form-label">{{ form.prog_1_premia.label }}</label>
+                    {{ form.prog_1_premia }}
+                    {% if form.prog_1_premia.errors %}<div class="invalid-feedback d-block">{{ form.prog_1_premia.errors }}</div>{% endif %}
+                </div>
+                <div class="col-md-3 mb-3">
+                    <label for="{{ form.prog_2.id_for_label }}" class="form-label">{{ form.prog_2.label }}</label>
+                    {{ form.prog_2 }}
+                    {% if form.prog_2.errors %}<div class="invalid-feedback d-block">{{ form.prog_2.errors }}</div>{% endif %}
+                </div>
+                <div class="col-md-3 mb-3">
+                    <label for="{{ form.prog_2_premia.id_for_label }}" class="form-label">{{ form.prog_2_premia.label }}</label>
+                    {{ form.prog_2_premia }}
+                    {% if form.prog_2_premia.errors %}<div class="invalid-feedback d-block">{{ form.prog_2_premia.errors }}</div>{% endif %}
+                </div>
+            </div>
+            <p class="form-text mb-0">
+                Premia za próg 2 ma pierwszeństwo przed premią za próg 1. Zostaw puste, jeśli zadanie ma tylko jeden próg.
+            </p>
+        </div>
+
+        <!-- Mix: próg mix i mnożnik -->
+        <div id="sekcja-mix" class="border rounded p-3 mb-3">
+            <p class="fw-bold mb-2">Parametry mix</p>
+            <div class="row">
+                <div class="col-md-4 mb-3">
+                    <label for="{{ form.prog_mix.id_for_label }}" class="form-label">{{ form.prog_mix.label }}</label>
+                    {{ form.prog_mix }}
+                    {% if form.prog_mix.errors %}<div class="invalid-feedback d-block">{{ form.prog_mix.errors }}</div>{% endif %}
+                </div>
+                <div class="col-md-4 mb-3" id="pole-mnoznik">
+                    <label for="{{ form.mnoznik_mix.id_for_label }}" class="form-label">{{ form.mnoznik_mix.label }}</label>
+                    {{ form.mnoznik_mix }}
+                    <div class="form-text">Np. 1.5 = stawka +50% po przekroczeniu progu.</div>
+                    {% if form.mnoznik_mix.errors %}<div class="invalid-feedback d-block">{{ form.mnoznik_mix.errors }}</div>{% endif %}
+                </div>
             </div>
         </div>
 
@@ -157,5 +209,5 @@
 {% endblock %}
 
 {% block extra_js %}
-<script src="{% static 'produkty/js/zadanie_form.js' %}"></script>
+<script src="{% static 'produkty/js/zadanie_form.js' %}?v=2"></script>
 {% endblock %}

--- a/produkty/tests_zadanie_form.py
+++ b/produkty/tests_zadanie_form.py
@@ -1,0 +1,106 @@
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth.models import User
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from .models import Produkt, Zadanie
+
+
+class ZadanieEdycjaPremiiTestCase(TestCase):
+    """Formularz zadania musi pozwalac ustawic premie i nie moze kasowac
+    juz zapisanych wartosci przy edycji."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="edytor", password="pass")
+        self.client = Client()
+        self.client.login(username="edytor", password="pass")
+        self.p = Produkt.objects.create(model="PRALKA1", stawka=Decimal("10"), grupa_towarowa="PRALKI", marka="BEKO")
+
+    def _zadanie(self, **kwargs):
+        dane = dict(
+            nazwa="Zadanie", data_start=date(2026, 7, 1), data_koniec=date(2026, 7, 31),
+            typ=Zadanie.Typ.KONKRETNE_MODELE, prog_1=5, prog_1_premia=Decimal("300"),
+        )
+        dane.update(kwargs)
+        z = Zadanie.objects.create(**dane)
+        z.produkty.add(self.p)
+        return z
+
+    def test_formularz_zawiera_pola_premii(self):
+        z = self._zadanie()
+        r = self.client.get(reverse("produkty:edytuj_zadanie", args=[z.id]))
+        self.assertEqual(r.status_code, 200)
+        for pole in ("prog_1_premia", "prog_2_premia", "prog_mix", "mnoznik_mix", "typ"):
+            self.assertContains(r, f'name="{pole}"', msg_prefix=f"Brak pola {pole} w formularzu")
+
+    def test_edycja_nie_kasuje_premii(self):
+        """Regresja: brak pol premii w szablonie powodowal ich wyzerowanie."""
+        z = self._zadanie(prog_2=8, prog_2_premia=Decimal("500"))
+        r = self.client.post(reverse("produkty:edytuj_zadanie", args=[z.id]), {
+            "nazwa": "Zadanie po edycji",
+            "opis": "",
+            "data_start": "2026-07-01",
+            "data_koniec": "2026-07-31",
+            "typ": Zadanie.Typ.KONKRETNE_MODELE,
+            "target": "ilosc",
+            "prog_1": 5,
+            "prog_1_premia": "300",
+            "prog_2": 8,
+            "prog_2_premia": "500",
+            "produkty": [self.p.id],
+        })
+        self.assertEqual(r.status_code, 302)
+        z.refresh_from_db()
+        self.assertEqual(z.nazwa, "Zadanie po edycji")
+        self.assertEqual(z.prog_1_premia, Decimal("300"))
+        self.assertEqual(z.prog_2_premia, Decimal("500"))
+        self.assertEqual(z.typ, Zadanie.Typ.KONKRETNE_MODELE)
+
+    def test_mozna_ustawic_premie_przez_formularz(self):
+        z = self._zadanie(prog_1_premia=None)
+        self.assertIsNone(z.prog_1_premia)
+        r = self.client.post(reverse("produkty:edytuj_zadanie", args=[z.id]), {
+            "nazwa": "Zadanie",
+            "opis": "",
+            "data_start": "2026-07-01",
+            "data_koniec": "2026-07-31",
+            "typ": Zadanie.Typ.KONKRETNE_MODELE,
+            "target": "ilosc",
+            "prog_1": 5,
+            "prog_1_premia": "250.50",
+            "produkty": [self.p.id],
+        })
+        self.assertEqual(r.status_code, 302)
+        z.refresh_from_db()
+        self.assertEqual(z.prog_1_premia, Decimal("250.50"))
+
+    def test_edycja_zadania_mnoznikowego_zachowuje_mnoznik(self):
+        z = self._zadanie(typ=Zadanie.Typ.MIX_MNOZNIK, prog_1=None, prog_1_premia=None,
+                          prog_mix=4, mnoznik_mix=Decimal("1.5"))
+        r = self.client.post(reverse("produkty:edytuj_zadanie", args=[z.id]), {
+            "nazwa": "Mnoznikowe",
+            "opis": "",
+            "data_start": "2026-07-01",
+            "data_koniec": "2026-07-31",
+            "typ": Zadanie.Typ.MIX_MNOZNIK,
+            "target": "ilosc",
+            "prog_mix": 4,
+            "mnoznik_mix": "2.0",
+            "produkty": [self.p.id],
+        })
+        self.assertEqual(r.status_code, 302)
+        z.refresh_from_db()
+        self.assertEqual(z.mnoznik_mix, Decimal("2.0"))
+        self.assertEqual(z.prog_mix, 4)
+        self.assertEqual(z.typ, Zadanie.Typ.MIX_MNOZNIK)
+
+    def test_stare_zadanie_bez_typu_dostaje_domyslny(self):
+        """Zadania zapisane wczesniej moga miec pusty typ - formularz ma
+        podstawic sensowna wartosc zamiast wysypywac walidacje."""
+        z = self._zadanie()
+        Zadanie.objects.filter(id=z.id).update(typ="")
+        r = self.client.get(reverse("produkty:edytuj_zadanie", args=[z.id]))
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.context["form"]["typ"].value(), Zadanie.Typ.KONKRETNE_MODELE)


### PR DESCRIPTION
## Problem

W formularzu zadania **nie dało się ustawić premii** — dlatego kasa liczyła się tylko z jednego zadania (tego z premią wpisaną wcześniej przez JSON), a pozostałe miały puste kwoty.

Przyczyna: szablon `zadanie_form.html` renderował tylko `prog_1` i `prog_2`. Brakowało **sześciu pól**, które są w formularzu, ale nigdy nie trafiały do HTML:

`typ` · `target` · `prog_1_premia` · `prog_2_premia` · `prog_mix` · `mnoznik_mix`

### Skutek uboczny, który był groźniejszy niż sam brak edycji

`ZadanieForm` to `ModelForm` — pola obecne w formularzu, ale nieobecne w wysłanym formularzu HTML, są traktowane jako **puste**. Czyli każda edycja zadania przez interfejs **kasowała** premie, typ zadania, mnożnik i próg mix. Zadanie mogło stracić kwotę premii samym otwarciem i zapisaniem.

## Naprawa

- Szablon renderuje teraz **wszystkie** pola rozliczenia, pogrupowane w dwie sekcje: **„Progi i premie"** oraz **„Parametry mix"**.
- Pola dostały czytelne etykiety i podpowiedzi (m.in. że premia za próg 2 ma pierwszeństwo, i co oznacza mnożnik 1.5).
- JS pokazuje sekcje właściwe dla wybranego typu zadania. **Sekcje są tylko ukrywane (`display:none`), nie usuwane z formularza** — dzięki temu przełączanie typu nie kasuje zapisanych wartości.
- Zadania zapisane przed wprowadzeniem typów mogą mieć pusty `typ`; formularz podstawia teraz „Konkretne modele", więc edycja nie wysypuje się na walidacji.

## Testy

`python manage.py test` — pełny zestaw przechodzi. 5 nowych testów, w tym dwa, które **nie przechodziły przed poprawką**:
- formularz zawiera pola `prog_1_premia`, `prog_2_premia`, `prog_mix`, `mnoznik_mix`, `typ`,
- stare zadanie z pustym typem dostaje domyślną wartość,
- edycja nie kasuje premii (regresja),
- można ustawić premię przez formularz,
- edycja zadania mnożnikowego zachowuje mnożnik i próg mix.

## Co zrobić po wdrożeniu

Wejdź w każde z trzech zadań bez premii i uzupełnij kwoty — od tego momentu będą się liczyć do zarobku w podsumowaniu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
